### PR TITLE
Avoid `include_path` dependency.

### DIFF
--- a/www/account_manager/groups.php
+++ b/www/account_manager/groups.php
@@ -1,8 +1,8 @@
 <?php
 
-include_once("web_functions.inc.php");
-include_once("ldap_functions.inc.php");
-include_once("module_functions.inc.php");
+include_once __DIR__ . "/../includes/web_functions.inc.php";
+include_once __DIR__ . "/../includes/ldap_functions.inc.php";
+include_once __DIR__ . "/../includes/module_functions.inc.php";
 set_page_access("admin");
 
 render_header("LDAP manager");

--- a/www/account_manager/index.php
+++ b/www/account_manager/index.php
@@ -1,8 +1,8 @@
 <?php
 
-include_once("web_functions.inc.php");
-include_once("ldap_functions.inc.php");
-include_once("module_functions.inc.php");
+include_once __DIR__ . "/../includes/web_functions.inc.php";
+include_once __DIR__ . "/../includes/ldap_functions.inc.php";
+include_once __DIR__ . "/../includes/module_functions.inc.php";
 set_page_access("admin");
 
 render_header("LDAP manager");

--- a/www/account_manager/new_user.php
+++ b/www/account_manager/new_user.php
@@ -1,8 +1,8 @@
 <?php
 
-include_once("web_functions.inc.php");
-include_once("ldap_functions.inc.php");
-include_once("module_functions.inc.php");
+include_once __DIR__ . "/../includes/web_functions.inc.php";
+include_once __DIR__ . "/../includes/ldap_functions.inc.php";
+include_once __DIR__ . "/../includes/module_functions.inc.php";
 
 if ( $_POST['setup_admin_account'] ) {
  $admin_setup = TRUE;

--- a/www/account_manager/show_group.php
+++ b/www/account_manager/show_group.php
@@ -1,8 +1,8 @@
 <?php
 
-include_once("web_functions.inc.php");
-include_once("ldap_functions.inc.php");
-include_once("module_functions.inc.php");
+include_once __DIR__ . "/../includes/web_functions.inc.php";
+include_once __DIR__ . "/../includes/ldap_functions.inc.php";
+include_once __DIR__ . "/../includes/module_functions.inc.php";
 set_page_access("admin");
 
 render_header("LDAP manager");

--- a/www/account_manager/show_user.php
+++ b/www/account_manager/show_user.php
@@ -1,8 +1,8 @@
 <?php
 
-include_once("web_functions.inc.php");
-include_once("ldap_functions.inc.php");
-include_once("module_functions.inc.php");
+include_once __DIR__ . "/../includes/web_functions.inc.php";
+include_once __DIR__ . "/../includes/ldap_functions.inc.php";
+include_once __DIR__ . "/../includes/module_functions.inc.php";
 set_page_access("admin");
 
 render_header();

--- a/www/change_password/index.php
+++ b/www/change_password/index.php
@@ -1,7 +1,7 @@
 <?php
 
-include_once("web_functions.inc.php");
-include_once("ldap_functions.inc.php");
+include_once __DIR__ . "/web_functions.inc.php";
+include_once __DIR__ . "/ldap_functions.inc.php";
 
 set_page_access("user");
 

--- a/www/change_password/index.php
+++ b/www/change_password/index.php
@@ -1,7 +1,7 @@
 <?php
 
-include_once __DIR__ . "/web_functions.inc.php";
-include_once __DIR__ . "/ldap_functions.inc.php";
+include_once __DIR__ . "/../includes/web_functions.inc.php";
+include_once __DIR__ . "/../includes/ldap_functions.inc.php";
 
 set_page_access("user");
 

--- a/www/index.php
+++ b/www/index.php
@@ -1,6 +1,6 @@
 <?php
 
-include_once("web_functions.inc.php");
+include_once __DIR__ . "/includes/web_functions.inc.php";
 render_header();
 
  if (isset($_GET['logged_out'])) {

--- a/www/log_in/index.php
+++ b/www/log_in/index.php
@@ -1,7 +1,7 @@
 <?php
 
-include("web_functions.inc.php");
-include("ldap_functions.inc.php");
+include __DIR__ . "/web_functions.inc.php";
+include __DIR__ . "/ldap_functions.inc.php";
 
 if (isset($_POST["user_id"]) and isset($_POST["password"])) {
 

--- a/www/log_in/index.php
+++ b/www/log_in/index.php
@@ -1,7 +1,7 @@
 <?php
 
-include __DIR__ . "/web_functions.inc.php";
-include __DIR__ . "/ldap_functions.inc.php";
+include __DIR__ . "/../includes/web_functions.inc.php";
+include __DIR__ . "/../includes/ldap_functions.inc.php";
 
 if (isset($_POST["user_id"]) and isset($_POST["password"])) {
 

--- a/www/log_out/index.php
+++ b/www/log_out/index.php
@@ -1,4 +1,4 @@
 <?php
-include("web_functions.inc.php");
+include __DIR__ . "/../includes/web_functions.inc.php";
 log_out();
 ?>

--- a/www/setup/index.php
+++ b/www/setup/index.php
@@ -1,7 +1,7 @@
 <?php
 
-include("web_functions.inc.php");
-include("ldap_functions.inc.php");
+include __DIR__ . "/../includes/web_functions.inc.php";
+include __DIR__ . "/../includes/ldap_functions.inc.php";
 
 if (isset($_POST["admin_password"])) {
 

--- a/www/setup/run_checks.php
+++ b/www/setup/run_checks.php
@@ -1,8 +1,8 @@
 <?php 
 
-include_once("web_functions.inc.php");
-include_once("ldap_functions.inc.php");
-include_once("module_functions.inc.php");
+include_once __DIR__ . "/../includes/web_functions.inc.php";
+include_once __DIR__ . "/../includes/ldap_functions.inc.php";
+include_once __DIR__ . "/../includes/module_functions.inc.php";
 
 validate_setup_cookie();
 set_page_access("setup");

--- a/www/setup/setup_ldap.php
+++ b/www/setup/setup_ldap.php
@@ -1,8 +1,8 @@
 <?php
 
-include_once("web_functions.inc.php");
-include_once("ldap_functions.inc.php");
-include_once("module_functions.inc.php");
+include_once __DIR__ . "/../includes/web_functions.inc.php";
+include_once __DIR__ . "/../includes/ldap_functions.inc.php";
+include_once __DIR__ . "/../includes/module_functions.inc.php";
 
 validate_setup_cookie();
 set_page_access("setup");


### PR DESCRIPTION
Use `__DIR__` to avoid dependency of `include_path` (for `includes/` in this case).