### PR TITLE
Add support for stronger hashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Optional:
 * `USERNAME_FORMAT` (default: *{first_name}-{last_name}*):  The template used to dynamically generate usernames.  See [Username format](#username-format).
 * `USERNAME_REGEX` (default: *^[a-z][a-zA-Z0-9\._-]{3,32}$*): The regular expression used to ensure a username (and group name) is valid.  See [Username format](#username-format).
 
-* `PASSWORD_HASH` (default: *SSHA*):  Select which hashing method which will be used to store passwords in LDAP.  Options are `MD5`, `SHA`, `SMD5`, `SSHA` or `CRYPT`.
+* `PASSWORD_HASH` (no default):  Select which hashing method which will be used to store passwords in LDAP.  Options are `CLEAR`, `BLOWFISH`, `EXT_DES`, `MD5CRYPT`, `SHA256CRYPT`, `SHA512CRYPT`, `MD5`, `SHA`, `SMD5`, `SSHA` or `CRYPT`. It is strongly encouraged to use `SHA256CRYPT` or stronger. Cleartext passwords should NEVER be used in any situation outside of a test. On a invalid hash type, a warning is thrown and `SHA512CRYPT` is used as a fallback.
 * `ACCEPT_WEAK_PASSWORDS` (default: *FALSE*):  Set this to *TRUE* to prevent a password being rejected for being too weak.  The password strength indicators will still gauge the strength of the password.  Don't enable this in a production environment.
    
 * `LOGIN_TIMEOUT_MINS` (default: 10 minutes):  How long before an idle session will be timed out.

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Optional:
 * `USERNAME_FORMAT` (default: *{first_name}-{last_name}*):  The template used to dynamically generate usernames.  See [Username format](#username-format).
 * `USERNAME_REGEX` (default: *^[a-z][a-zA-Z0-9\._-]{3,32}$*): The regular expression used to ensure a username (and group name) is valid.  See [Username format](#username-format).
 
-* `PASSWORD_HASH` (no default):  Select which hashing method which will be used to store passwords in LDAP.  Options are `CLEAR`, `BLOWFISH`, `EXT_DES`, `MD5CRYPT`, `SHA256CRYPT`, `SHA512CRYPT`, `MD5`, `SHA`, `SMD5`, `SSHA` or `CRYPT`. It is strongly encouraged to use `SHA256CRYPT` or stronger. Cleartext passwords should NEVER be used in any situation outside of a test. On a invalid hash type, a warning is thrown and `SHA512CRYPT` is used as a fallback.
+* `PASSWORD_HASH` (no default):  Select which hashing method which will be used to store passwords in LDAP.  Options are `CLEAR`, `BLOWFISH`, `EXT_DES`, `MD5CRYPT`, `SHA256CRYPT`, `SHA512CRYPT`, `MD5`, `SHA`, `SMD5`, `SSHA` or `CRYPT`.  Cleartext passwords should NEVER be used in any situation outside of a test. On a invalid hash type, a warning is thrown and `SSHA` is used as a fallback. It is strongly encouraged to use `SHA256CRYPT` or stronger and to explicitly set this instead of relying on the fallback.
 * `ACCEPT_WEAK_PASSWORDS` (default: *FALSE*):  Set this to *TRUE* to prevent a password being rejected for being too weak.  The password strength indicators will still gauge the strength of the password.  Don't enable this in a production environment.
    
 * `LOGIN_TIMEOUT_MINS` (default: 10 minutes):  How long before an idle session will be timed out.

--- a/www/includes/config.inc.php
+++ b/www/includes/config.inc.php
@@ -43,8 +43,11 @@
  $USERNAME_REGEX = (getenv('USERNAME_REGEX') ? getenv('USERNAME_REGEX') : '^[a-z][a-zA-Z0-9\._-]{3,32}$');
  #We'll use the username regex for groups too.
 
- $PASSWORD_HASH = (getenv('PASSWORD_HASH') ? getenv('PASSWORD_HASH') : 'SSHA');
- if ( ! in_array($PASSWORD_HASH, array('MD5','SMD5','SHA','SSHA','CRYPT'))) { $PASSWORD_HASH = 'SSHA'; }
+ $PASSWORD_HASH = strtoupper(getenv('PASSWORD_HASH') ? getenv('PASSWORD_HASH') : 'SSHA');
+//  $valid_hashes = array('CLEAR', 'BLOWFISH', 'EXT_DES', 'MD5CRYPT', 'SHA256CRYPT', 'SHA512CRYPT', 'MD5','SMD5','SHA','SSHA','CRYPT');
+//  if ( ! in_array($PASSWORD_HASH, $valid_hashes)) {
+//    $PASSWORD_HASH = 'SSHA';
+//  }
 
  $ACCEPT_WEAK_PASSWORDS = ((strcasecmp(getenv('ACCEPT_WEAK_PASSWORDS'),'TRUE') == 0) ? TRUE : FALSE);
 

--- a/www/includes/config.inc.php
+++ b/www/includes/config.inc.php
@@ -44,10 +44,6 @@
  #We'll use the username regex for groups too.
 
  $PASSWORD_HASH = strtoupper(getenv('PASSWORD_HASH') ? getenv('PASSWORD_HASH') : 'SSHA');
-//  $valid_hashes = array('CLEAR', 'BLOWFISH', 'EXT_DES', 'MD5CRYPT', 'SHA256CRYPT', 'SHA512CRYPT', 'MD5','SMD5','SHA','SSHA','CRYPT');
-//  if ( ! in_array($PASSWORD_HASH, $valid_hashes)) {
-//    $PASSWORD_HASH = 'SSHA';
-//  }
 
  $ACCEPT_WEAK_PASSWORDS = ((strcasecmp(getenv('ACCEPT_WEAK_PASSWORDS'),'TRUE') == 0) ? TRUE : FALSE);
 

--- a/www/includes/ldap_functions.inc.php
+++ b/www/includes/ldap_functions.inc.php
@@ -215,19 +215,12 @@ function ldap_hashed_password($password) {
   case 'SHA':
     $hashed_pwd = '{SHA}' . base64_encode(sha1($password, TRUE));
     break;
-  
-  case 'SSHA':
-    $salt = generate_salt(8);
-    $hashed_pwd = '{SSHA}' . base64_encode(sha1($password . $salt, TRUE) . $salt);
-    break;
 
   case 'CRYPT':
     $salt = generate_salt(2);
     $hashed_pwd = '{CRYPT}' . crypt($password, $salt);
     break;
   
-  default:
-    error_log("$log_prefix: Unknown or unsupported hash type $PASSWORD_HASH, falling back to SHA512CRYPT", E_USER_WARNING);
   case 'SHA512CRYPT':
     if (!defined('CRYPT_SHA512') || CRYPT_SHA512 == 0) {
       throw new RuntimeException('Your system does not support sha512crypt encryptions');
@@ -236,6 +229,12 @@ function ldap_hashed_password($password) {
     $hashed_pwd = '{CRYPT}' . crypt($password, '$6$' . generate_salt(8));
     break;
 
+  default:
+    error_log("$log_prefix: Unknown or unsupported hash type $PASSWORD_HASH, falling back to SSHA", E_USER_WARNING);
+  case 'SSHA':
+    $salt = generate_salt(8);
+    $hashed_pwd = '{SSHA}' . base64_encode(sha1($password . $salt, TRUE) . $salt);
+    break;
  }
  
  return $hashed_pwd;

--- a/www/includes/ldap_functions.inc.php
+++ b/www/includes/ldap_functions.inc.php
@@ -160,7 +160,7 @@ function generate_salt($length) {
 
 function ldap_hashed_password($password) {
 
- global $PASSWORD_HASH;
+ global $PASSWORD_HASH, $log_prefix;
  
  switch (strtoupper($PASSWORD_HASH)) {
 
@@ -223,11 +223,11 @@ function ldap_hashed_password($password) {
 
   case 'CRYPT':
     $salt = generate_salt(2);
-    $hashed_pwd = '{crypt}' . crypt($password, $salt);
+    $hashed_pwd = '{CRYPT}' . crypt($password, $salt);
     break;
   
   default:
-    trigger_error("Unknown or unsupported hash type $PASSWORD_HASH, falling back to SHA256CRYPT.", E_USER_WARNING);
+    error_log("$log_prefix: Unknown or unsupported hash type $PASSWORD_HASH, falling back to SHA512CRYPT.", E_USER_WARNING);
   case 'SHA512CRYPT':
     if (!defined('CRYPT_SHA512') || CRYPT_SHA512 == 0) {
       throw new RuntimeException('Your system does not support sha512crypt encryptions');

--- a/www/includes/ldap_functions.inc.php
+++ b/www/includes/ldap_functions.inc.php
@@ -190,6 +190,14 @@ function ldap_hashed_password($password) {
     $hashed_pwd = '{CRYPT}' .  crypt($password, '_' . random_salt(8));
     break;
   
+  case 'MD5CRYPT':
+    if (!defined('CRYPT_MD5') || CRYPT_MD5 == 0) {
+      throw new RuntimeException('Your system does not support md5crypt encryptions');
+    }
+
+    $hashed_pwd = '{CRYPT}' .  crypt($password, '$1$' . random_salt(9));
+    break;
+  
   case 'MD5':
    $hashed_pwd = '{MD5}' . base64_encode(md5($password,TRUE));
    break;

--- a/www/includes/ldap_functions.inc.php
+++ b/www/includes/ldap_functions.inc.php
@@ -179,7 +179,7 @@ function ldap_hashed_password($password) {
       throw new RuntimeException('Your system does not support blowfish encryptions');
     }
     
-    $hashed_pwd = '{CRYPT}' .  crypt($password, '$2a$12$' . random_salt(13));
+    $hashed_pwd = '{CRYPT}' .  crypt($password, '$2a$12$' . generate_salt(13));
     break;
   
   case 'EXT_DES':
@@ -187,7 +187,7 @@ function ldap_hashed_password($password) {
       throw new RuntimeException('Your system does not support extended DES encryptions');
     }
 
-    $hashed_pwd = '{CRYPT}' .  crypt($password, '_' . random_salt(8));
+    $hashed_pwd = '{CRYPT}' .  crypt($password, '_' . generate_salt(8));
     break;
   
   case 'MD5CRYPT':
@@ -195,7 +195,7 @@ function ldap_hashed_password($password) {
       throw new RuntimeException('Your system does not support md5crypt encryptions');
     }
 
-    $hashed_pwd = '{CRYPT}' .  crypt($password, '$1$' . random_salt(9));
+    $hashed_pwd = '{CRYPT}' .  crypt($password, '$1$' . generate_salt(9));
     break;
   
   case 'MD5':

--- a/www/includes/ldap_functions.inc.php
+++ b/www/includes/ldap_functions.inc.php
@@ -174,6 +174,14 @@ function ldap_hashed_password($password) {
     $hashed_pwd = $password;
     break;
   
+  case 'BLOWFISH':
+    if (!defined('CRYPT_BLOWFISH') || CRYPT_BLOWFISH == 0) {
+      throw new RuntimeException('Your system does not support blowfish encryptions');
+    }
+    
+    $hashed_pwd = '{CRYPT}' .  crypt($password, '$2a$12$' . random_salt(13));
+    break;
+  
   case 'MD5':
    $hashed_pwd = '{MD5}' . base64_encode(md5($password,TRUE));
    break;

--- a/www/includes/ldap_functions.inc.php
+++ b/www/includes/ldap_functions.inc.php
@@ -205,6 +205,14 @@ function ldap_hashed_password($password) {
 
     $hashed_pwd = '{CRYPT}' . crypt($password, '$5$' . generate_salt(8));
     break;
+  
+  case 'SHA512CRYPT':
+    if (!defined('CRYPT_SHA512') || CRYPT_SHA512 == 0) {
+      throw new RuntimeException('Your system does not support sha512crypt encryptions');
+    }
+
+    $hashed_pwd = '{CRYPT}' . crypt($password, '$6$' . generate_salt(8));
+    break;
 
   case 'MD5':
    $hashed_pwd = '{MD5}' . base64_encode(md5($password,TRUE));

--- a/www/includes/ldap_functions.inc.php
+++ b/www/includes/ldap_functions.inc.php
@@ -162,9 +162,6 @@ function ldap_hashed_password($password) {
 
  global $PASSWORD_HASH;
 
- $permitted_chars = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
- $salt = substr(str_shuffle($permitted_chars), 0, 64);
-
  switch (strtoupper($PASSWORD_HASH)) {
 
   case 'CLEAR':
@@ -215,24 +212,27 @@ function ldap_hashed_password($password) {
     break;
 
   case 'MD5':
-   $hashed_pwd = '{MD5}' . base64_encode(md5($password,TRUE));
-   break;
+    $hashed_pwd = '{MD5}' . base64_encode(md5($password, TRUE));
+    break;
 
   case 'SMD5':
-   $hashed_pwd = '{SMD5}' . base64_encode(md5($password.$salt,TRUE) . $salt);
-   break;
+    $salt = generate_salt(8);
+    $hashed_pwd = '{SMD5}' . base64_encode(md5($password . $salt, TRUE) . $salt);
+    break;
 
   case 'SHA':
-   $hashed_pwd = '{SHA}' . base64_encode(sha1($password,TRUE));
-   break;
+    $hashed_pwd = '{SHA}' . base64_encode(sha1($password, TRUE));
+    break;
 
   case 'SSHA':
-   $hashed_pwd = '{SSHA}' . base64_encode(sha1($password.$salt,TRUE) . $salt);
-   break;
+    $salt = generate_salt(8);
+    $hashed_pwd = '{SSHA}' . base64_encode(sha1($password . $salt, TRUE) . $salt);
+    break;
 
   case 'CRYPT':
-   $hashed_pwd = '{crypt}' . crypt($password, $salt);
-   break;
+    $salt = generate_salt(2);
+    $hashed_pwd = '{crypt}' . crypt($password, $salt);
+    break;
 
  }
 

--- a/www/includes/ldap_functions.inc.php
+++ b/www/includes/ldap_functions.inc.php
@@ -198,6 +198,14 @@ function ldap_hashed_password($password) {
     $hashed_pwd = '{CRYPT}' .  crypt($password, '$1$' . generate_salt(9));
     break;
   
+  case 'SHA256CRYPT':
+    if (!defined('CRYPT_SHA256') || CRYPT_SHA256 == 0) {
+      throw new RuntimeException('Your system does not support sha256crypt encryptions');
+    }
+
+    $hashed_pwd = '{CRYPT}' . crypt($password, '$5$' . generate_salt(8));
+    break;
+
   case 'MD5':
    $hashed_pwd = '{MD5}' . base64_encode(md5($password,TRUE));
    break;

--- a/www/includes/ldap_functions.inc.php
+++ b/www/includes/ldap_functions.inc.php
@@ -182,6 +182,14 @@ function ldap_hashed_password($password) {
     $hashed_pwd = '{CRYPT}' .  crypt($password, '$2a$12$' . random_salt(13));
     break;
   
+  case 'EXT_DES':
+    if (!defined('CRYPT_EXT_DES') || CRYPT_EXT_DES == 0) {
+      throw new RuntimeException('Your system does not support extended DES encryptions');
+    }
+
+    $hashed_pwd = '{CRYPT}' .  crypt($password, '_' . random_salt(8));
+    break;
+  
   case 'MD5':
    $hashed_pwd = '{MD5}' . base64_encode(md5($password,TRUE));
    break;

--- a/www/includes/ldap_functions.inc.php
+++ b/www/includes/ldap_functions.inc.php
@@ -227,7 +227,7 @@ function ldap_hashed_password($password) {
     break;
   
   default:
-    error_log("$log_prefix: Unknown or unsupported hash type $PASSWORD_HASH, falling back to SHA512CRYPT.", E_USER_WARNING);
+    error_log("$log_prefix: Unknown or unsupported hash type $PASSWORD_HASH, falling back to SHA512CRYPT", E_USER_WARNING);
   case 'SHA512CRYPT':
     if (!defined('CRYPT_SHA512') || CRYPT_SHA512 == 0) {
       throw new RuntimeException('Your system does not support sha512crypt encryptions');

--- a/www/includes/ldap_functions.inc.php
+++ b/www/includes/ldap_functions.inc.php
@@ -167,6 +167,13 @@ function ldap_hashed_password($password) {
 
  switch (strtoupper($PASSWORD_HASH)) {
 
+  case 'CLEAR':
+    trigger_error('Saving password in cleartext. This is extremely bad pratice ' . 
+                  'and should never ever be done in a production environment.', E_USER_WARNING);
+    
+    $hashed_pwd = $password;
+    break;
+  
   case 'MD5':
    $hashed_pwd = '{MD5}' . base64_encode(md5($password,TRUE));
    break;

--- a/www/includes/ldap_functions.inc.php
+++ b/www/includes/ldap_functions.inc.php
@@ -140,6 +140,21 @@ function ldap_setup_auth($ldap_connection, $password) {
 }
 
 
+#################################
+
+function generate_salt($length) {
+	$permitted_chars = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ./';
+  
+	mt_srand((double)microtime() * 1000000);
+
+  $salt = '';
+	while (strlen($salt) < $length) {
+    $salt .= substr($permitted_chars, (rand() % strlen($permitted_chars)), 1);
+  }
+
+	return $salt;
+}
+
 
 ##################################
 

--- a/www/includes/ldap_functions.inc.php
+++ b/www/includes/ldap_functions.inc.php
@@ -224,14 +224,16 @@ function ldap_hashed_password($password) {
     $hashed_pwd = '{SHA}' . base64_encode(sha1($password, TRUE));
     break;
 
-  case 'SSHA':
-    $salt = generate_salt(8);
-    $hashed_pwd = '{SSHA}' . base64_encode(sha1($password . $salt, TRUE) . $salt);
-    break;
-
   case 'CRYPT':
     $salt = generate_salt(2);
     $hashed_pwd = '{crypt}' . crypt($password, $salt);
+    break;
+  
+  default:
+    trigger_error("Unknown or unsupported hash type $PASSWORD_HASH, falling back to SSHA.", E_USER_WARNING);
+  case 'SSHA':
+    $salt = generate_salt(8);
+    $hashed_pwd = '{SSHA}' . base64_encode(sha1($password . $salt, TRUE) . $salt);
     break;
 
  }


### PR DESCRIPTION
Adds support for stronger hashes like sha256crypt and sha512crypt, while also adding support for legacy ones.  
Also fixes a critical bug where updating a password would simply set it as cleartext.

Closes #32.