### PR TITLE
Fix for missing condition for disabling ACCOUNT_REQUESTS_ENABLED

### DIFF
--- a/www/includes/config.inc.php
+++ b/www/includes/config.inc.php
@@ -76,7 +76,7 @@
  ###
 
  $ACCOUNT_REQUESTS_ENABLED = ((strcasecmp(getenv('ACCOUNT_REQUESTS_ENABLED'),'TRUE') == 0) ? TRUE : FALSE);
- if ($EMAIL_SENDING_ENABLED == FALSE) { 
+if (($EMAIL_SENDING_ENABLED == FALSE) && ($ACCOUNT_REQUESTS_ENABLED == TRUE)) {
    $ACCOUNT_REQUESTS_ENABLED = FALSE;
    error_log("$log_prefix Config: ACCOUNT_REQUESTS_ENABLED was set to TRUE but SMTP_HOSTNAME wasn't set, so account requesting has been disabled as we can't send out the request email",0);
  }


### PR DESCRIPTION
Changed the condition in which the ACCOUNT_REQUESTS_ENABLED is disabled. Only disable it if it is not previously disabled.