### PR TITLE
Fixed a regex syntax error on line 34

### DIFF
--- a/www/includes/ldap_functions.inc.php
+++ b/www/includes/ldap_functions.inc.php
@@ -31,7 +31,7 @@ function open_ldap_connection($ldap_bind=TRUE) {
     exit(0);
    }
    else {
-    if ($SENT_HEADERS == TRUE and !preg_match('/^ldap:\/\/localhost(:[0-9]+)?$', $LDAP['uri']) and !preg_match('/^ldap:\/\/127\.0\.0\.([0-9]+)(:[0-9]+)$', $LDAP['uri'])) {
+    if ($SENT_HEADERS == TRUE and !preg_match('/^ldap:\/\/localhost(:[0-9]+)?$/', $LDAP['uri']) and !preg_match('/^ldap:\/\/127\.0\.0\.([0-9]+)(:[0-9]+)$/', $LDAP['uri'])) {
       print "<div style='position: fixed;bottom: 0px;width: 100%;height: 20px;border-bottom:solid 20px yellow;'>WARNING: Insecure LDAP connection to ${LDAP['uri']}</div>";
     }
     ldap_close($ldap_connection);


### PR DESCRIPTION
Line 34 regex was missing trailing / required in PHP, was causing errors to show on screen.