### PR TITLE
Implement Remote Headers Auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ These settings should only be changed if you're trying to make the user manager 
    
 * `ACCEPT_WEAK_PASSWORDS` (default: *FALSE*):  Set this to *TRUE* to prevent a password being rejected for being too weak.  The password strength indicators will still gauge the strength of the password.  Don't enable this in a production environment.
    
+* `REMOTE_HTTP_HEADERS_LOGIN`(default: *FALSE*) Enables session managment from a external Service like Authelia. This setting compromisses your security if your not using a Auth-Proxy infront of this application
 
 #### Email sending settings
 

--- a/www/includes/config.inc.php
+++ b/www/includes/config.inc.php
@@ -106,6 +106,12 @@
 
  ###
 
+ ###
+
+ $REMOTE_HTTP_HEADERS_LOGIN = ((strcasecmp(getenv('REMOTE_HTTP_HEADERS_LOGIN'),'TRUE') == 0) ? TRUE : FALSE);
+ 
+ ###
+
  $errors = "";
 
  if (empty($LDAP['uri'])) {

--- a/www/includes/modules.inc.php
+++ b/www/includes/modules.inc.php
@@ -11,11 +11,13 @@
                     'log_in'          => 'hidden_on_login',
                     'change_password' => 'auth',
                     'account_manager' => 'admin',
-                    'log_out'         => 'auth'
                   );
 
 if ($ACCOUNT_REQUESTS_ENABLED == TRUE) {
   $MODULES['request_account'] = 'hidden_on_login';
+}
+if (!$REMOTE_HTTP_HEADERS_LOGIN) {
+  $MODULES['log_out'] = 'auth';
 }
 
 ?>

--- a/www/includes/web_functions.inc.php
+++ b/www/includes/web_functions.inc.php
@@ -1,5 +1,4 @@
 <?php
-
 #Security level vars
 
 $VALIDATED = FALSE;
@@ -43,10 +42,13 @@ $DEFAULT_COOKIE_OPTIONS = array( 'expires' => time()+(60 * $SESSION_TIMEOUT),
                                  'samesite' => 'strict'
                                );
 
-validate_passkey_cookie();
 
+if($REMOTE_HTTP_HEADERS_LOGIN) {
+  login_via_headers();
+} else {
+  validate_passkey_cookie();
+}
 ######################################################
-
 function generate_passkey() {
 
  $rnd1 = rand(10000000,100000000000);
@@ -84,7 +86,16 @@ function set_passkey_cookie($user_id,$is_admin) {
  $VALIDATED = TRUE;
 
 }
+function login_via_headers() {
+  global $IS_ADMIN, $USER_ID, $VALIDATED, $LDAP;
+  //['admins_group'];
+  $USER_ID = $_SERVER['HTTP_REMOTE_USER'];
+  $remote_groups = explode(',',$_SERVER['HTTP_REMOTE_GROUPS']);
+  $IS_ADMIN = in_array($LDAP['admins_group'],$remote_groups);
+  // users are always validated as we assume, that the auth server does this
+  $VALIDATED = true;
 
+}
 
 ######################################################
 
@@ -136,7 +147,6 @@ function validate_passkey_cookie() {
    }
   }
  }
-
 }
 
 


### PR DESCRIPTION
This Pull Request implement Remote HTTP Headers, for fronted auth Proxies like Authelia or Traffik Forwardauth.

It is only tested with Authelia so, i don't know if it would work with traefik

This allows user that use SSO, for the services to only login once.
More information to how it works can be found here: https://www.authelia.com/docs/deployment/supported-proxies/#how-can-the-backend-be-aware-of-the-authenticated-users