### PR TITLE
Gh actionto auto publish docker image

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -22,7 +22,7 @@ jobs:
         uses: docker/metadata-action@v3
         with:
           # list of Docker images to use as base name for tags
-          images: registry.hub.docker.com/${{ secrets.DOCKER_USERNAME_TOKEN }}/ldap-user-manager
+          images: registry.hub.docker.com/${{ secrets.DOCKER_REGISTRY_USERNAME }}/ldap-user-manager
           # generate Docker tags based on the following events/attributes
           tags: |
             type=ref,event=branch

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -4,9 +4,8 @@ on:
   push:
     branches:
       - 'master'
-      - 'gh-action'
     tags:
-      - '*.*.*'
+      - v'*.*'
 
 jobs:
   docker:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,55 @@
+name: Docker publish
+
+on:
+  push:
+    branches:
+      - 'master'
+      - 'gh-action'
+    tags:
+      - '*.*.*'
+
+jobs:
+  docker:
+    environment: docker-registry
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+      -
+        name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          # list of Docker images to use as base name for tags
+          images: registry.hub.docker.com/${{ secrets.DOCKER_USERNAME_TOKEN }}/ldap-user-manager
+          # generate Docker tags based on the following events/attributes
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Login to registry
+        uses: docker/login-action@v1
+        with:
+          registry: registry.hub.docker.com
+          username: ${{ secrets.DOCKER_REGISTRY_USERNAME }}
+          password: ${{ secrets.DOCKER_REGISTRY_TOKEN }}
+      -
+        name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          secrets: |
+            GIT_AUTH_TOKEN=${{ secrets.DOCKER_REGISTRY_TOKEN }}


### PR DESCRIPTION
Hello @wheelybird ,

I set a GitHub action to auto build and publish the docker image (master branch and tags).

To use it, set a environments with to secrets : `DOCKER_REGISTRY_USERNAME` and `DOCKER_REGISTRY_TOKEN`

- Create the `docker-registry` environment

![image](https://user-images.githubusercontent.com/18330770/147272068-e45cc4fb-b3eb-4735-9c8e-e55f3309c363.png)

- Add the secrets:

![image](https://user-images.githubusercontent.com/18330770/147272124-7161cfc4-15db-4dbe-8fc0-c20ac35e494a.png)
![image](https://user-images.githubusercontent.com/18330770/147272133-2125a808-391f-4e94-a83d-8ed3ea5b574f.png)

The dockerhub token is obtained on dockerhub :

![image](https://user-images.githubusercontent.com/18330770/147272302-635b659c-49b2-4914-86f8-982f56b84d87.png)


