### PR TITLE
Replace deprecated FILTER_SANITIZE_STRING

### DIFF
--- a/www/account_manager/new_user.php
+++ b/www/account_manager/new_user.php
@@ -44,7 +44,7 @@ $new_account_r = array();
 
 foreach ($attribute_map as $attribute => $attr_r) {
  if (isset($_POST[$attribute])) {
-  $$attribute = filter_var($_POST[$attribute], FILTER_SANITIZE_STRING);
+  $$attribute = sanitize_input_string($_POST[$attribute]);
  }
  elseif (isset($attr_r['default'])) {
   $$attribute = $attr_r['default'];
@@ -56,10 +56,10 @@ foreach ($attribute_map as $attribute => $attr_r) {
 
 if (isset($_GET['account_request'])) {
 
-  $givenname=filter_var($_GET['first_name'], FILTER_SANITIZE_STRING);
+  $givenname=sanitize_input_string($_GET['first_name']);
   $new_account_r['givenname'] = $givenname;
 
-  $sn=filter_var($_GET['last_name'], FILTER_SANITIZE_STRING);
+  $sn=sanitize_input_string($_GET['last_name']);
   $new_account_r['sn'] = $sn;
 
   $uid = generate_username($givenname,$sn);
@@ -74,7 +74,7 @@ if (isset($_GET['account_request'])) {
 
   $new_account_r['cn'] = $cn;
 
-  $mail=filter_var($_GET['email'], FILTER_SANITIZE_EMAIL);
+  $mail=sanitize_input_string($_GET['email']);
   if ($mail == "") {
     if (isset($EMAIL_DOMAIN)) {
       $mail = $uid . "@" . $EMAIL_DOMAIN;

--- a/www/account_manager/show_user.php
+++ b/www/account_manager/show_user.php
@@ -53,7 +53,7 @@ if ($ldap_search) {
    $$attribute = $user[0][$attribute][0];
 
    if (isset($_POST['update_account']) and isset($_POST[$attribute]) and $_POST[$attribute] != $$attribute) {
-     $$attribute = filter_var($_POST[$attribute], FILTER_SANITIZE_STRING);
+     $$attribute = sanitize_input_string($_POST[$attribute]);
      $to_update[$attribute] = $$attribute;
    }
    elseif (isset($attr_r['default'])) {

--- a/www/includes/ldap_functions.inc.php
+++ b/www/includes/ldap_functions.inc.php
@@ -700,19 +700,19 @@ function ldap_complete_account_attribute_array() {
 
     $this_r = array();
     $kv = explode(":", $this_attr);
-    $attr_name = strtolower(filter_var($kv[0], FILTER_SANITIZE_STRING));
+    $attr_name = strtolower(sanitize_input_string($kv[0]));
 
     if (preg_match('/^[a-zA-Z0-9\-]+$/', $attr_name) == 1) {
 
      if (isset($kv[1]) and $kv[1] != "") {
-      $this_r['label'] = filter_var($kv[1], FILTER_SANITIZE_STRING);
+      $this_r['label'] = sanitize_input_string($kv[1]);
      }
      else {
       $this_r['label'] = $attr_name;
      }
 
      if (isset($kv[2]) and $kv[2] != "") {
-      $this_r['default'] = filter_var($kv[2], FILTER_SANITIZE_STRING);
+      $this_r['default'] = sanitize_input_string($kv[2]);
      }
 
      $additional_attributes_r[$attr_name] = $this_r;

--- a/www/includes/web_functions.inc.php
+++ b/www/includes/web_functions.inc.php
@@ -545,4 +545,10 @@ EoRenderEmailJS;
 
 }
 
+
+function sanitize_input_string(string $string) {
+    $str = preg_replace('/\x00|<[^>]*>?/', '', $string);
+    return str_replace(["'", '"'], ['&#39;', '&#34;'], $str);
+}
+
 ?>

--- a/www/request_account/index.php
+++ b/www/request_account/index.php
@@ -28,22 +28,22 @@ if($_POST) {
     array_push($error_messages, "You didn't enter your first name.");
   }
   else {
-    $firstname=filter_var($_POST['firstname'], FILTER_SANITIZE_STRING);
+    $firstname=sanitize_input_string($_POST['firstname']);
   }
 
   if (! isset($_POST['lastname']) or $_POST['lastname'] == "") {
     array_push($error_messages, "You didn't enter your first name.");
   }
   else {
-    $lastname=filter_var($_POST['lastname'], FILTER_SANITIZE_STRING);
+    $lastname=sanitize_input_string($_POST['lastname']);
   }
 
   if (isset($_POST['email']) and $_POST['email'] != "") {
-    $email=filter_var($_POST['email'], FILTER_SANITIZE_EMAIL);
+    $email=sanitize_input_string($_POST['email']);
   }
 
   if (isset($_POST['notes']) and $_POST['notes'] != "") {
-    $notes=filter_var($_POST['notes'], FILTER_SANITIZE_STRING);
+    $notes=sanitize_input_string($_POST['notes']);
   }
 
 


### PR DESCRIPTION
I replaced all instances of `filter_var(x, FILTER_SANITIZE_STRING)` with an equivalent polyfill.

This fixes the `Deprecated: Constant FILTER_SANITIZE_STRING is deprecated` warning messages in PHP8

Source: https://stackoverflow.com/a/69207369