### PR TITLE
Feature/support modern password hashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ These settings should only be changed if you're trying to make the user manager 
    
 * `USERNAME_REGEX` (default: *^[a-z][a-zA-Z0-9\._-]{3,32}$*): The regular expression used to ensure account names and group names are safe to use on servers.  See [Username format](#username-format).
    
-* `PASSWORD_HASH` (no default):  Select which hashing method which will be used to store passwords in LDAP.  Options are (in order of precedence) `SHA512CRYPT`, `SHA256CRYPT`, `MD5CRYPT`, `SSHA`, `SHA`, `SMD5`, `MD5`, `CRYPT` & `CLEAR`.  If your chosen method isn't available on your system then the strongest available method will be automatically selected - `SSHA` is the strongest method guaranteed to be available.  Cleartext passwords should NEVER be used in any situation outside of a test.
+* `PASSWORD_HASH` (no default):  Select which hashing method which will be used to store passwords in LDAP.  Options are (in order of precedence) `SHA512CRYPT`, `SHA256CRYPT`, `MD5CRYPT`, `SSHA`, `SHA`, `SMD5`, `MD5`, `ARGON2`, `CRYPT` & `CLEAR`.  If your chosen method isn't available on your system then the strongest available method will be automatically selected - `SSHA` is the strongest method guaranteed to be available. Note that for `ARGON2` to work you need to have the ARGON2 plugin enabled, if you do not the passwords will be saved but the user cannot authenticate against it. Cleartext passwords should NEVER be used in any situation outside of a test.
    
 * `ACCEPT_WEAK_PASSWORDS` (default: *FALSE*):  Set this to *TRUE* to prevent a password being rejected for being too weak.  The password strength indicators will still gauge the strength of the password.  Don't enable this in a production environment.
    

--- a/www/includes/ldap_functions.inc.php
+++ b/www/includes/ldap_functions.inc.php
@@ -205,6 +205,7 @@ function ldap_hashed_password($password) {
                             "SHA",
                             "SMD5",
                             "MD5",
+                            "ARGON2",
                             "CRYPT",
                             "CLEAR"
                           );
@@ -274,6 +275,10 @@ function ldap_hashed_password($password) {
   case 'SSHA':
     $salt = generate_salt(8);
     $hashed_pwd = '{SSHA}' . base64_encode(sha1($password . $salt, TRUE) . $salt);
+    break;
+
+  case 'ARGON2':
+    $hashed_pwd = password_hash($password, PASSWORD_ARGON2ID, ['memory_cost' => 2048, 'time_cost' => 4, 'threads' => 3]);
     break;
 
   case 'CRYPT':

--- a/www/includes/ldap_functions.inc.php
+++ b/www/includes/ldap_functions.inc.php
@@ -278,7 +278,7 @@ function ldap_hashed_password($password) {
     break;
 
   case 'ARGON2':
-    $hashed_pwd = password_hash($password, PASSWORD_ARGON2ID, ['memory_cost' => 2048, 'time_cost' => 4, 'threads' => 3]);
+    $hashed_pwd = '{ARGON2}' . password_hash($password, PASSWORD_ARGON2ID, ['memory_cost' => 2048, 'time_cost' => 4, 'threads' => 3]);
     break;
 
   case 'CRYPT':


### PR DESCRIPTION
# Description
This implements the ARGON2 hashing algorithm. In order to use this, the LDAP server needs to have the ARGON2 plugin compiled, installed and activated.

This addresses feature request issue #180

# How to use?
## Use a container with compiled ARGON2 plugin
For testing use a LDAP container with ARGON2 installed. For example the one from [tiredofit](https://github.com/tiredofit/docker-openldap) 

## Enable ARGON2
ARGON2 needs to be activated as well using, for example by using the following LDIF:
```
dn: cn=module{0},cn=config
changetype: modify
add: olcModuleLoad
olcModuleLoad: {1}argon2.la
```

## (Optional) Set as default

```
dn: olcDatabase={-1}frontend,cn=config
changetype: modify
add: olcPasswordHash
olcPasswordHash: {ARGON2}
```

## Tell ldap-user-manager to use ARGON2

Set the env variable `PASSWORD_HASH` to `ARGON2`