### PR TITLE
fix string deprecation

### DIFF
--- a/www/account_manager/download.php
+++ b/www/account_manager/download.php
@@ -30,7 +30,7 @@ if ($ldap_search) {
         header("Content-Type: application/octet-stream");
         header("Cache-Control: no-cache private");
         header("Content-Transfer-Encoding: Binary");
-        header("Content-disposition: attachment; filename='${this_resource}.${this_attribute}'");
+        header("Content-disposition: attachment; filename='{$this_resource}.{$this_attribute}'");
         header("Content-Length: ". strlen($this_record[$this_attribute][0]));
         print $this_record[$this_attribute][0];
       }

--- a/www/account_manager/groups.php
+++ b/www/account_manager/groups.php
@@ -51,7 +51,7 @@ render_js_username_check();
 <div class="container">
 
  <div class="form-inline" id="new_group_div">
-  <form action="<?php print "${THIS_MODULE_PATH}"; ?>/show_group.php" method="post">
+  <form action="<?php print "{$THIS_MODULE_PATH}"; ?>/show_group.php" method="post">
    <input type="hidden" name="new_group">
    <button type="button" class="btn btn-light"><?php print count($groups);?> group<?php if (count($groups) != 1) { print "s"; }?></button>  &nbsp;  <button id="show_new_group" class="form-control btn btn-default" type="button" onclick="show_new_group_form();">New group</button>
    <input type="text" class="form-control invisible" name="group_name" id="group_name" placeholder="Group name" onkeyup="check_entity_name_validity(document.getElementById('group_name').value,'new_group_div');"><button id="add_group" class="form-control btn btn-primary btn-sm invisible" type="submit">Add</button>
@@ -77,7 +77,7 @@ render_js_username_check();
   </script>
 <?php
 foreach ($groups as $group){
- print " <tr>\n   <td><a href='${THIS_MODULE_PATH}/show_group.php?group_name=" . urlencode($group) . "'>$group</a></td>\n </tr>\n";
+ print " <tr>\n   <td><a href='{$THIS_MODULE_PATH}/show_group.php?group_name=" . urlencode($group) . "'>$group</a></td>\n </tr>\n";
 }
 ?>
   </tbody>

--- a/www/account_manager/index.php
+++ b/www/account_manager/index.php
@@ -63,7 +63,7 @@ foreach ($people as $account_identifier => $attribs){
 
   $group_membership = ldap_user_group_membership($ldap_connection,$account_identifier);
   if (isset($people[$account_identifier]['mail'])) { $this_mail = $people[$account_identifier]['mail']; } else { $this_mail = ""; }
-  print " <tr>\n   <td><a href='${THIS_MODULE_PATH}/show_user.php?account_identifier=" . urlencode($account_identifier) . "'>$account_identifier</a></td>\n";
+  print " <tr>\n   <td><a href='{$THIS_MODULE_PATH}/show_user.php?account_identifier=" . urlencode($account_identifier) . "'>$account_identifier</a></td>\n";
   print "   <td>" . $people[$account_identifier]['givenname'] . "</td>\n";
   print "   <td>" . $people[$account_identifier]['sn'] . "</td>\n";
   print "   <td>$this_mail</td>\n"; 

--- a/www/account_manager/module_functions.inc.php
+++ b/www/account_manager/module_functions.inc.php
@@ -24,7 +24,7 @@ function render_submenu() {
        else {
         print '<li>';
        }
-       print "<a href='${THIS_MODULE_PATH}/{$path}'>" . ucwords($submodule) . "</a></li>\n";
+       print "<a href='{$THIS_MODULE_PATH}/{$path}'>" . ucwords($submodule) . "</a></li>\n";
 
       }
      ?>

--- a/www/account_manager/new_user.php
+++ b/www/account_manager/new_user.php
@@ -20,7 +20,7 @@ if ( isset($_POST['setup_admin_account']) ) {
   validate_setup_cookie();
   set_page_access("setup");
 
-  $completed_action="${SERVER_PATH}log_in";
+  $completed_action="{$SERVER_PATH}log_in";
   $page_title="New administrator account";
 
   render_header("$ORGANISATION_NAME account manager - setup administrator account", FALSE);
@@ -29,7 +29,7 @@ if ( isset($_POST['setup_admin_account']) ) {
 else {
   set_page_access("admin");
 
-  $completed_action="${THIS_MODULE_PATH}/";
+  $completed_action="{$THIS_MODULE_PATH}/";
   $page_title="New account";
   $admin_setup = FALSE;
 

--- a/www/account_manager/show_group.php
+++ b/www/account_manager/show_group.php
@@ -61,7 +61,7 @@ if (isset($_POST['new_group'])) {
 }
 elseif (isset($_POST['initialise_group'])) {
   $initialise_group = TRUE;
-  $full_dn = "${LDAP['group_attribute']}=$group_cn,${LDAP['group_dn']}";
+  $full_dn = "{$LDAP['group_attribute']}=$group_cn,{$LDAP['group_dn']}";
   $has_been = "created";
 }
 else {
@@ -216,7 +216,7 @@ if (isset($_POST["update_members"])) {
       render_alert_banner("Groups can't be empty, so the final member hasn't been removed.  You could try deleting the group","danger",15000);
     }
     else {
-      render_alert_banner("The group has been ${has_been}.");
+      render_alert_banner("The group has been {$has_been}.");
     }
 
   }
@@ -349,7 +349,7 @@ ldap_close($ldap_connection);
         <div class="panel-heading clearfix">
           <h3 class="panel-title pull-left" style="padding-top: 7.5px;"><?php print $group_cn; ?><?php if ($group_cn == $LDAP["admins_group"]) { print " <sup>(admin group)</sup>" ; } ?></h3>
           <button class="btn btn-warning pull-right" onclick="show_delete_group_button();" <?php if ($group_cn == $LDAP["admins_group"]) { print "disabled"; } ?>>Delete group</button>
-          <form action="<?php print "${THIS_MODULE_PATH}"; ?>/groups.php" method="post" enctype="multipart/form-data"><input type="hidden" name="delete_group" value="<?php print $group_cn; ?>"><button class="btn btn-danger pull-right invisible" id="delete_group">Confirm deletion</button></form>
+          <form action="<?php print "{$THIS_MODULE_PATH}"; ?>/groups.php" method="post" enctype="multipart/form-data"><input type="hidden" name="delete_group" value="<?php print $group_cn; ?>"><button class="btn btn-danger pull-right invisible" id="delete_group">Confirm deletion</button></form>
         </div>
 
         <ul class="list-group">

--- a/www/account_manager/show_user.php
+++ b/www/account_manager/show_user.php
@@ -41,7 +41,7 @@ else {
 }
 
 $ldap_connection = open_ldap_connection();
-$ldap_search_query="(${LDAP['account_attribute']}=". ldap_escape($account_identifier, "", LDAP_ESCAPE_FILTER) . ")";
+$ldap_search_query="({$LDAP['account_attribute']}=". ldap_escape($account_identifier, "", LDAP_ESCAPE_FILTER) . ")";
 $ldap_search = ldap_search( $ldap_connection, $LDAP['user_dn'], $ldap_search_query);
 
 
@@ -156,15 +156,15 @@ if ($ldap_search) {
   if (array_key_exists($LDAP['account_attribute'], $to_update)) {
     $account_attribute = $LDAP['account_attribute'];
     $new_account_identifier = $to_update[$account_attribute][0];
-    $new_rdn = "${account_attribute}=${new_account_identifier}";
+    $new_rdn = "{$account_attribute}={$new_account_identifier}";
     $renamed_entry = ldap_rename($ldap_connection, $dn, $new_rdn, $LDAP['user_dn'], true);
     if ($renamed_entry) {
-      $dn = "${new_rdn},${LDAP['user_dn']}";
+      $dn = "{$new_rdn},{$LDAP['user_dn']}";
       $account_identifier = $new_account_identifier;
     }
     else {
       ldap_get_option($ldap_connection, LDAP_OPT_DIAGNOSTIC_MESSAGE, $detailed_err);
-      error_log("$log_prefix Failed to rename the DN for ${account_identifier}: " . ldap_error($ldap_connection) . " -- " . $detailed_err,0);
+      error_log("$log_prefix Failed to rename the DN for {$account_identifier}: " . ldap_error($ldap_connection) . " -- " . $detailed_err,0);
     }
   }
 
@@ -176,7 +176,7 @@ if ($ldap_search) {
 
   if (!$updated_account) {
     ldap_get_option($ldap_connection, LDAP_OPT_DIAGNOSTIC_MESSAGE, $detailed_err);
-    error_log("$log_prefix Failed to modify account details for ${account_identifier}: " . ldap_error($ldap_connection) . " -- " . $detailed_err,0);
+    error_log("$log_prefix Failed to modify account details for {$account_identifier}: " . ldap_error($ldap_connection) . " -- " . $detailed_err,0);
   }
 
   $sent_email_message="";
@@ -187,9 +187,9 @@ if ($ldap_search) {
       $mail_body = parse_mail_text($new_account_mail_body, $password, $account_identifier, $givenname[0], $sn[0]);
       $mail_subject = parse_mail_text($new_account_mail_subject, $password, $account_identifier, $givenname[0], $sn[0]);
 
-      $sent_email = send_email($mail[0],"${givenname[0]} ${sn[0]}",$mail_subject,$mail_body);
+      $sent_email = send_email($mail[0],"{$givenname[0]} {$sn[0]}",$mail_subject,$mail_body);
       if ($sent_email) {
-        $sent_email_message .= "  An email sent to ${mail[0]}.";
+        $sent_email_message .= "  An email sent to {$mail[0]}.";
       }
       else {
         $sent_email_message .= "  Unfortunately the email wasn't sent; check the logs for more information.";
@@ -443,7 +443,7 @@ if ($ldap_search) {
     <div class="panel-heading clearfix">
      <span class="panel-title pull-left"><h3><?php print $account_identifier; ?></h3></span>
      <button class="btn btn-warning pull-right align-self-end" style="margin-top: auto;" onclick="show_delete_user_button();" <?php if ($account_identifier == $USER_ID) { print "disabled"; }?>>Delete account</button>
-     <form action="<?php print "${THIS_MODULE_PATH}"; ?>/index.php" method="post"><input type="hidden" name="delete_user" value="<?php print urlencode($account_identifier); ?>"><button class="btn btn-danger pull-right invisible" id="delete_user">Confirm deletion</button></form>
+     <form action="<?php print "{$THIS_MODULE_PATH}"; ?>/index.php" method="post"><input type="hidden" name="delete_user" value="<?php print urlencode($account_identifier); ?>"><button class="btn btn-danger pull-right invisible" id="delete_user">Confirm deletion</button></form>
     </div>
     <ul class="list-group">
       <li class="list-group-item"><?php print $dn; ?></li>
@@ -542,7 +542,7 @@ if ($ldap_search) {
             <?php
             foreach ($member_of as $group) {
               if ($group == $LDAP["admins_group"] and $USER_ID == $account_identifier) {
-                print "<div class='list-group-item' style='opacity: 0.5; pointer-events:none;'>${group}</div>\n";
+                print "<div class='list-group-item' style='opacity: 0.5; pointer-events:none;'>{$group}</div>\n";
               }
               else {
                 print "<li class='list-group-item'>$group</li>\n";

--- a/www/includes/config.inc.php
+++ b/www/includes/config.inc.php
@@ -83,8 +83,8 @@
    if (strtoupper(getenv('LDAP_GROUP_MEMBERSHIP_USES_UID')) == 'FALSE' )  { $LDAP['group_membership_uses_uid']  = FALSE; }
  }
 
- $LDAP['group_dn'] = "ou=${LDAP['group_ou']},${LDAP['base_dn']}";
- $LDAP['user_dn'] = "ou=${LDAP['user_ou']},${LDAP['base_dn']}";
+ $LDAP['group_dn'] = "ou={$LDAP['group_ou']},{$LDAP['base_dn']}";
+ $LDAP['user_dn'] = "ou={$LDAP['user_ou']},{$LDAP['base_dn']}";
 
  if (isset($account_additional_objectclasses) and $account_additional_objectclasses != "") {
    $LDAP['account_objectclasses'] = array_merge($LDAP['account_objectclasses'], explode(",", $account_additional_objectclasses));

--- a/www/includes/ldap_functions.inc.php
+++ b/www/includes/ldap_functions.inc.php
@@ -10,8 +10,8 @@ function open_ldap_connection($ldap_bind=TRUE) {
  $ldap_connection = @ ldap_connect($LDAP['uri']);
 
  if (!$ldap_connection) {
-  print "Problem: Can't connect to the LDAP server at ${LDAP['uri']}";
-  die("Can't connect to the LDAP server at ${LDAP['uri']}");
+  print "Problem: Can't connect to the LDAP server at {$LDAP['uri']}";
+  die("Can't connect to the LDAP server at {$LDAP['uri']}");
   exit(1);
  }
 
@@ -24,15 +24,15 @@ function open_ldap_connection($ldap_bind=TRUE) {
 
   if ($tls_result != TRUE) {
 
-   if (!preg_match('/^ldap:\/\/127\.0\.0\.([0-9]+)(:[0-9]+)$/', $LDAP['uri'])) { error_log("$log_prefix Failed to start STARTTLS connection to ${LDAP['uri']}: " . ldap_error($ldap_connection),0); }
+   if (!preg_match('/^ldap:\/\/127\.0\.0\.([0-9]+)(:[0-9]+)$/', $LDAP['uri'])) { error_log("$log_prefix Failed to start STARTTLS connection to {$LDAP['uri']}: " . ldap_error($ldap_connection),0); }
 
    if ($LDAP["require_starttls"] == TRUE) {
-    print "<div style='position: fixed;bottom: 0;width: 100%;' class='alert alert-danger'>Fatal:  Couldn't create a secure connection to ${LDAP['uri']} and LDAP_REQUIRE_STARTTLS is TRUE.</div>";
+    print "<div style='position: fixed;bottom: 0;width: 100%;' class='alert alert-danger'>Fatal:  Couldn't create a secure connection to {$LDAP['uri']} and LDAP_REQUIRE_STARTTLS is TRUE.</div>";
     exit(0);
    }
    else {
     if ($SENT_HEADERS == TRUE and !preg_match('/^ldap:\/\/localhost(:[0-9]+)?$/', $LDAP['uri']) and !preg_match('/^ldap:\/\/127\.0\.0\.([0-9]+)(:[0-9]+)$/', $LDAP['uri'])) {
-      print "<div style='position: fixed;bottom: 0px;width: 100%;height: 20px;border-bottom:solid 20px yellow;'>WARNING: Insecure LDAP connection to ${LDAP['uri']}</div>";
+      print "<div style='position: fixed;bottom: 0px;width: 100%;height: 20px;border-bottom:solid 20px yellow;'>WARNING: Insecure LDAP connection to {$LDAP['uri']}</div>";
     }
     ldap_close($ldap_connection);
     $ldap_connection = @ ldap_connect($LDAP['uri']);
@@ -41,7 +41,7 @@ function open_ldap_connection($ldap_bind=TRUE) {
   }
   else {
    if ($LDAP_DEBUG == TRUE) {
-    error_log("$log_prefix Start STARTTLS connection to ${LDAP['uri']}",0);
+    error_log("$log_prefix Start STARTTLS connection to {$LDAP['uri']}",0);
    }
    $LDAP['connection_type'] = "StartTLS";
   }
@@ -49,29 +49,29 @@ function open_ldap_connection($ldap_bind=TRUE) {
  }
  else {
   if ($LDAP_DEBUG == TRUE) {
-    error_log("$log_prefix Using an LDAPS encrypted connection to ${LDAP['uri']}",0);
+    error_log("$log_prefix Using an LDAPS encrypted connection to {$LDAP['uri']}",0);
    }
    $LDAP['connection_type'] = 'LDAPS';
  }
 
  if ($ldap_bind == TRUE) {
 
-   if ($LDAP_DEBUG == TRUE) { error_log("$log_prefix Attempting to bind to ${LDAP['uri']} as ${LDAP['admin_bind_dn']}",0); }
+   if ($LDAP_DEBUG == TRUE) { error_log("$log_prefix Attempting to bind to {$LDAP['uri']} as {$LDAP['admin_bind_dn']}",0); }
    $bind_result = @ ldap_bind( $ldap_connection, $LDAP['admin_bind_dn'], $LDAP['admin_bind_pwd']);
 
    if ($bind_result != TRUE) {
 
-     $this_error = "Failed to bind to ${LDAP['uri']} as ${LDAP['admin_bind_dn']}";
-     if ($LDAP_DEBUG == TRUE) { $this_error .= " with password ${LDAP['admin_bind_pwd']}"; }
+     $this_error = "Failed to bind to {$LDAP['uri']} as {$LDAP['admin_bind_dn']}";
+     if ($LDAP_DEBUG == TRUE) { $this_error .= " with password {$LDAP['admin_bind_pwd']}"; }
      $this_error .= ": " . ldap_error($ldap_connection);
-     print "Problem: Failed to bind as ${LDAP['admin_bind_dn']}";
+     print "Problem: Failed to bind as {$LDAP['admin_bind_dn']}";
      error_log("$log_prefix $this_error",0);
 
      exit(1);
 
    }
    elseif ($LDAP_DEBUG == TRUE) {
-     error_log("$log_prefix Bound successfully as ${LDAP['admin_bind_dn']}",0);
+     error_log("$log_prefix Bound successfully as {$LDAP['admin_bind_dn']}",0);
    }
 
  }
@@ -90,7 +90,7 @@ function ldap_auth_username($ldap_connection,$username, $password) {
 
  global $log_prefix, $LDAP, $LDAP_DEBUG;
 
- $ldap_search_query="${LDAP['account_attribute']}=" . ldap_escape($username, "", LDAP_ESCAPE_FILTER);
+ $ldap_search_query="{$LDAP['account_attribute']}=" . ldap_escape($username, "", LDAP_ESCAPE_FILTER);
  if ($LDAP_DEBUG == TRUE) { error_log("$log_prefix Running LDAP search for: $ldap_search_query"); }
 
  $ldap_search = @ ldap_search( $ldap_connection, $LDAP['user_dn'], $ldap_search_query );
@@ -102,38 +102,38 @@ function ldap_auth_username($ldap_connection,$username, $password) {
 
  $result = @ ldap_get_entries($ldap_connection, $ldap_search);
  if (!$result) {
-  error_log("$log_prefix Couldn't get LDAP entries for ${username}: " . ldap_error($ldap_connection),0);
+  error_log("$log_prefix Couldn't get LDAP entries for {$username}: " . ldap_error($ldap_connection),0);
   return FALSE;
  }
  if ($LDAP_DEBUG == TRUE) {
    error_log("$log_prefix LDAP search returned " . $result["count"] . " records for $ldap_search_query",0);
    for ($i=1; $i==$result["count"]; $i++) {
-     error_log("$log_prefix ". "Entry ${i}: " . $result[$i-1]['dn'], 0);
+     error_log("$log_prefix ". "Entry {$i}: " . $result[$i-1]['dn'], 0);
    }
  }
 
  if ($result["count"] == 1) {
 
   $this_dn = $result[0]['dn'];
-  if ($LDAP_DEBUG == TRUE) { error_log("$log_prefix Attempting authenticate as $username by binding with ${this_dn} ",0); }
+  if ($LDAP_DEBUG == TRUE) { error_log("$log_prefix Attempting authenticate as $username by binding with {$this_dn} ",0); }
   $auth_ldap_connection = open_ldap_connection(FALSE);
   $can_bind =  @ ldap_bind( $auth_ldap_connection, $result[0]['dn'], $password);
 
   if ($can_bind) {
    preg_match("/{$LDAP['account_attribute']}=(.*?),/",$result[0]['dn'],$dn_match);
-   if ($LDAP_DEBUG == TRUE) { error_log("$log_prefix Able to bind as ${username}",0); }
+   if ($LDAP_DEBUG == TRUE) { error_log("$log_prefix Able to bind as {$username}",0); }
    ldap_close($auth_ldap_connection);
    return $dn_match[1];
   }
   else {
-   if ($LDAP_DEBUG == TRUE) { error_log("$log_prefix Unable to bind as ${username}: " . ldap_error($auth_ldap_connection),0); }
+   if ($LDAP_DEBUG == TRUE) { error_log("$log_prefix Unable to bind as {$username}: " . ldap_error($auth_ldap_connection),0); }
    ldap_close($auth_ldap_connection);
    return FALSE;
   }
 
  }
  elseif ($result["count"] > 1) {
-   if ($LDAP_DEBUG == TRUE) { error_log("$log_prefix There was more than one entry for ${ldap_search_query} so it wasn't possible to determine which user to log in as."); }
+   if ($LDAP_DEBUG == TRUE) { error_log("$log_prefix There was more than one entry for {$ldap_search_query} so it wasn't possible to determine which user to log in as."); }
  }
 
 }
@@ -147,16 +147,16 @@ function ldap_setup_auth($ldap_connection, $password) {
  #credentials as passed in ADMIN_BIND_*
  global $log_prefix, $LDAP, $LDAP_DEBUG;
 
-  if ($LDAP_DEBUG == TRUE) { error_log("$log_prefix Initial setup: opening another LDAP connection to test authentication as ${LDAP['admin_bind_dn']}.",0); }
+  if ($LDAP_DEBUG == TRUE) { error_log("$log_prefix Initial setup: opening another LDAP connection to test authentication as {$LDAP['admin_bind_dn']}.",0); }
   $auth_ldap_connection = open_ldap_connection();
   $can_bind = @ldap_bind($auth_ldap_connection, $LDAP['admin_bind_dn'], $password);
   ldap_close($auth_ldap_connection);
   if ($can_bind) {
-    if ($LDAP_DEBUG == TRUE) { error_log("$log_prefix Initial setup: able to authenticate as ${LDAP['admin_bind_dn']}.",0); }
+    if ($LDAP_DEBUG == TRUE) { error_log("$log_prefix Initial setup: able to authenticate as {$LDAP['admin_bind_dn']}.",0); }
     return TRUE;
   }
   else {
-    $this_error="Initial setup: Unable to authenticate as ${LDAP['admin_bind_dn']}";
+    $this_error="Initial setup: Unable to authenticate as {$LDAP['admin_bind_dn']}";
     if ($LDAP_DEBUG == TRUE) { $this_error .= " with password $password"; }
     $this_error .= ". The password used to authenticate for /setup should be the same as set by LDAP_ADMIN_BIND_PWD. ";
     $this_error .= ldap_error($ldap_connection);
@@ -217,7 +217,7 @@ function ldap_hashed_password($password) {
      array_push($available_algos, $algo_name);
    }
    else {
-     error_log("$log_prefix password hashing - the system doesn't support ${algo_name}",0);
+     error_log("$log_prefix password hashing - the system doesn't support {$algo_name}",0);
    }
  }
  $available_algos = array_merge($available_algos, $remaining_algos);
@@ -234,7 +234,7 @@ function ldap_hashed_password($password) {
  else {
    $hash_algo = $available_algos[0];
  }
- error_log("$log_prefix LDAP password: using '${hash_algo}' as the hashing method",0);
+ error_log("$log_prefix LDAP password: using '{$hash_algo}' as the hashing method",0);
 
  switch ($hash_algo) {
 
@@ -308,15 +308,15 @@ function ldap_get_user_list($ldap_connection,$start=0,$entries=NULL,$sort="asc",
 
  global $log_prefix, $LDAP, $LDAP_DEBUG;
 
- if (!isset($fields)) { $fields = array_unique( array("${LDAP['account_attribute']}", "givenname", "sn", "mail")); }
+ if (!isset($fields)) { $fields = array_unique( array("{$LDAP['account_attribute']}", "givenname", "sn", "mail")); }
 
  if (!isset($sort_key)) { $sort_key = $LDAP['account_attribute']; }
 
- $this_filter = "(&(${LDAP['account_attribute']}=*)$filters)";
+ $this_filter = "(&({$LDAP['account_attribute']}=*)$filters)";
 
- $ldap_search = @ ldap_search($ldap_connection, "${LDAP['user_dn']}", $this_filter, $fields);
+ $ldap_search = @ ldap_search($ldap_connection, "{$LDAP['user_dn']}", $this_filter, $fields);
  $result = @ ldap_get_entries($ldap_connection, $ldap_search);
- if ($LDAP_DEBUG == TRUE) { error_log("$log_prefix LDAP returned ${result['count']} users for ${LDAP['user_dn']} when using this filter: $this_filter",0); }
+ if ($LDAP_DEBUG == TRUE) { error_log("$log_prefix LDAP returned {$result['count']} users for {$LDAP['user_dn']} when using this filter: $this_filter",0); }
 
  $records = array();
  foreach ($result as $record) {
@@ -347,8 +347,8 @@ function fetch_id_stored_in_ldap($ldap_connection,$type="uid") {
 
   global $log_prefix, $LDAP, $LDAP_DEBUG;
 
-  $filter = "(&(objectclass=device)(cn=last${type}))";
-  $ldap_search = @ ldap_search($ldap_connection, "${LDAP['base_dn']}", $filter, array('serialNumber'));
+  $filter = "(&(objectclass=device)(cn=last{$type}))";
+  $ldap_search = @ ldap_search($ldap_connection, "{$LDAP['base_dn']}", $filter, array('serialNumber'));
   $result = ldap_get_entries($ldap_connection, $ldap_search);
 
   if (isset($result[0]['serialnumber'][0]) and is_numeric($result[0]['serialnumber'][0])){
@@ -371,7 +371,7 @@ function ldap_get_highest_id($ldap_connection,$type="uid") {
  if ($type == "uid") {
   $this_id = $min_uid;
   $record_base_dn = $LDAP['user_dn'];
-  $record_filter = "(${LDAP['account_attribute']}=*)";
+  $record_filter = "({$LDAP['account_attribute']}=*)";
   $record_attribute = "uidnumber";
  }
  else {
@@ -417,10 +417,10 @@ function ldap_get_group_list($ldap_connection,$start=0,$entries=NULL,$sort="asc"
  global $log_prefix, $LDAP, $LDAP_DEBUG;
 
  $this_filter = "(&(objectclass=*)$filters)";
- $ldap_search = @ ldap_search($ldap_connection, "${LDAP['group_dn']}", $this_filter);
+ $ldap_search = @ ldap_search($ldap_connection, "{$LDAP['group_dn']}", $this_filter);
 
  $result = @ ldap_get_entries($ldap_connection, $ldap_search);
- if ($LDAP_DEBUG == TRUE) { error_log("$log_prefix LDAP returned ${result['count']} groups for ${LDAP['group_dn']} when using this filter: $this_filter",0); }
+ if ($LDAP_DEBUG == TRUE) { error_log("$log_prefix LDAP returned {$result['count']} groups for {$LDAP['group_dn']} when using this filter: $this_filter",0); }
 
  $records = array();
  foreach ($result as $record) {
@@ -449,8 +449,8 @@ function ldap_get_group_entry($ldap_connection,$group_name) {
 
  if (isset($group_name)) {
 
-  $ldap_search_query = "(${LDAP['group_attribute']}=" . ldap_escape($group_name, "", LDAP_ESCAPE_FILTER) . ")";
-  $ldap_search = @ ldap_search($ldap_connection, "${LDAP['group_dn']}", $ldap_search_query);
+  $ldap_search_query = "({$LDAP['group_attribute']}=" . ldap_escape($group_name, "", LDAP_ESCAPE_FILTER) . ")";
+  $ldap_search = @ ldap_search($ldap_connection, "{$LDAP['group_dn']}", $ldap_search_query);
   $result = @ ldap_get_entries($ldap_connection, $ldap_search);
 
   if ($result['count'] > 0) {
@@ -474,8 +474,8 @@ function ldap_get_group_members($ldap_connection,$group_name,$start=0,$entries=N
 
  $rfc2307bis_available = ldap_detect_rfc2307bis($ldap_connection);
 
- $ldap_search_query = "(${LDAP['group_attribute']}=". ldap_escape($group_name, "", LDAP_ESCAPE_FILTER) . ")";
- $ldap_search = @ ldap_search($ldap_connection, "${LDAP['group_dn']}", $ldap_search_query, array($LDAP['group_membership_attribute']));
+ $ldap_search_query = "({$LDAP['group_attribute']}=". ldap_escape($group_name, "", LDAP_ESCAPE_FILTER) . ")";
+ $ldap_search = @ ldap_search($ldap_connection, "{$LDAP['group_dn']}", $ldap_search_query, array($LDAP['group_membership_attribute']));
 
  $result = @ ldap_get_entries($ldap_connection, $ldap_search);
  if ($result) { $result_count = $result['count']; } else { $result_count = 0; }
@@ -489,13 +489,13 @@ function ldap_get_group_members($ldap_connection,$group_name,$start=0,$entries=N
    if ($key !== 'count' and !empty($value)) {
     $this_member = preg_replace("/^.*?=(.*?),.*/", "$1", $value);
     array_push($records, $this_member);
-    if ($LDAP_DEBUG == TRUE) { error_log("$log_prefix ${value} is a member",0); }
+    if ($LDAP_DEBUG == TRUE) { error_log("$log_prefix {$value} is a member",0); }
    }
 
   }
 
   $actual_result_count = count($records);
-  if ($LDAP_DEBUG == TRUE) { error_log("$log_prefix LDAP returned $actual_result_count members of ${group_name} when using this search: $ldap_search_query and this filter: ${LDAP['group_membership_attribute']}",0); }
+  if ($LDAP_DEBUG == TRUE) { error_log("$log_prefix LDAP returned $actual_result_count members of {$group_name} when using this search: $ldap_search_query and this filter: {$LDAP['group_membership_attribute']}",0); }
 
   if ($actual_result_count > 0) {
    if ($sort == "asc") { sort($records); } else { rsort($records); }
@@ -521,17 +521,17 @@ function ldap_is_group_member($ldap_connection,$group_name,$username) {
 
  $rfc2307bis_available = ldap_detect_rfc2307bis($ldap_connection);
 
- $ldap_search_query = "(${LDAP['group_attribute']}=" . ldap_escape($group_name, "", LDAP_ESCAPE_FILTER) . ")";
- $ldap_search = @ ldap_search($ldap_connection, "${LDAP['group_dn']}", $ldap_search_query);
+ $ldap_search_query = "({$LDAP['group_attribute']}=" . ldap_escape($group_name, "", LDAP_ESCAPE_FILTER) . ")";
+ $ldap_search = @ ldap_search($ldap_connection, "{$LDAP['group_dn']}", $ldap_search_query);
 
  if ($ldap_search) {
    $result = ldap_get_entries($ldap_connection, $ldap_search);
 
    if ($LDAP['group_membership_uses_uid'] == FALSE) {
-     $username = "${LDAP['account_attribute']}=$username,${LDAP['user_dn']}";
+     $username = "{$LDAP['account_attribute']}=$username,{$LDAP['user_dn']}";
    }
 
-   if (preg_grep ("/^${username}$/i", $result[0][$LDAP['group_membership_attribute']])) {
+   if (preg_grep ("/^{$username}$/i", $result[0][$LDAP['group_membership_attribute']])) {
      return TRUE;
    }
    else {
@@ -554,11 +554,11 @@ function ldap_user_group_membership($ldap_connection,$username) {
  $rfc2307bis_available = ldap_detect_rfc2307bis($ldap_connection);
 
  if ($LDAP['group_membership_uses_uid'] == FALSE) {
-  $username = "${LDAP['account_attribute']}=$username,${LDAP['user_dn']}";
+  $username = "{$LDAP['account_attribute']}=$username,{$LDAP['user_dn']}";
  }
 
- $ldap_search_query = "(&(objectClass=posixGroup)(${LDAP['group_membership_attribute']}=${username}))";
- $ldap_search = @ ldap_search($ldap_connection, "${LDAP['group_dn']}", $ldap_search_query, array($LDAP['group_attribute']));
+ $ldap_search_query = "(&(objectClass=posixGroup)({$LDAP['group_membership_attribute']}={$username}))";
+ $ldap_search = @ ldap_search($ldap_connection, "{$LDAP['group_dn']}", $ldap_search_query, array($LDAP['group_attribute']));
  $result = ldap_get_entries($ldap_connection, $ldap_search);
 
  $groups = array();
@@ -587,13 +587,13 @@ function ldap_new_group($ldap_connection,$group_name,$initial_member="",$extra_a
    $initial_member = ldap_escape($initial_member, "", LDAP_ESCAPE_FILTER);
    $update_gid_store=FALSE;
 
-   $ldap_search_query = "(${LDAP['group_attribute']}=$new_group,${LDAP['group_dn']})";
-   $ldap_search = @ ldap_search($ldap_connection, "${LDAP['group_dn']}", $ldap_search_query);
+   $ldap_search_query = "({$LDAP['group_attribute']}=$new_group,{$LDAP['group_dn']})";
+   $ldap_search = @ ldap_search($ldap_connection, "{$LDAP['group_dn']}", $ldap_search_query);
    $result = @ ldap_get_entries($ldap_connection, $ldap_search);
 
    if ($result['count'] == 0) {
 
-     if ($LDAP['group_membership_uses_uid'] == FALSE and $initial_member != "") { $initial_member = "${LDAP['account_attribute']}=$initial_member,${LDAP['user_dn']}"; }
+     if ($LDAP['group_membership_uses_uid'] == FALSE and $initial_member != "") { $initial_member = "{$LDAP['account_attribute']}=$initial_member,{$LDAP['user_dn']}"; }
 
      $new_group_array=array( 'objectClass' => $LDAP['group_objectclasses'],
                              'cn' => $new_group,
@@ -609,12 +609,12 @@ function ldap_new_group($ldap_connection,$group_name,$initial_member="",$extra_a
        $update_gid_store=TRUE;
      }
 
-     $group_dn="cn=$new_group,${LDAP['group_dn']}";
+     $group_dn="cn=$new_group,{$LDAP['group_dn']}";
 
      $add_group = @ ldap_add($ldap_connection, $group_dn, $new_group_array);
 
      if (! $add_group ) {
-       $this_error="$log_prefix LDAP: unable to add new group (${group_dn}): " . ldap_error($ldap_connection);
+       $this_error="$log_prefix LDAP: unable to add new group ({$group_dn}): " . ldap_error($ldap_connection);
        if ($LDAP_DEBUG == TRUE) { error_log("$log_prefix DEBUG add_group array: ". strip_tags(print_r($new_group_array,true)),0); }
        error_log($this_error,0);
      }
@@ -624,7 +624,7 @@ function ldap_new_group($ldap_connection,$group_name,$initial_member="",$extra_a
        if ($update_gid_store == TRUE) {
          $this_gid = fetch_id_stored_in_ldap($ldap_connection,"gid");
          if ($this_gid != FALSE) {
-           $update_gid = @ ldap_mod_replace($ldap_connection, "cn=lastGID,${LDAP['base_dn']}", array( 'serialNumber' => $new_gid ));
+           $update_gid = @ ldap_mod_replace($ldap_connection, "cn=lastGID,{$LDAP['base_dn']}", array( 'serialNumber' => $new_gid ));
            if ($update_gid) {
              error_log("$log_prefix Updated cn=lastGID with $new_gid",0);
            }
@@ -659,12 +659,12 @@ function ldap_update_group_attributes($ldap_connection,$group_name,$extra_attrib
  if (isset($group_name) and (count($extra_attributes) > 0)) {
 
   $group_name = ldap_escape($group_name, "", LDAP_ESCAPE_FILTER);
-  $group_dn = "${LDAP['group_attribute']}=$group_name,${LDAP['group_dn']}";
+  $group_dn = "{$LDAP['group_attribute']}=$group_name,{$LDAP['group_dn']}";
 
   $update_group = @ ldap_mod_replace($ldap_connection, $group_dn, $extra_attributes);
 
   if (!$update_group ) {
-    $this_error="$log_prefix LDAP: unable to update group attributes for group (${group_dn}): " . ldap_error($ldap_connection);
+    $this_error="$log_prefix LDAP: unable to update group attributes for group ({$group_dn}): " . ldap_error($ldap_connection);
     if ($LDAP_DEBUG == TRUE) { error_log("$log_prefix DEBUG update group attributes array: ". print_r($extra_attributes,true),0); }
     error_log($this_error,0);
     return FALSE;
@@ -689,7 +689,7 @@ function ldap_delete_group($ldap_connection,$group_name) {
 
  if (isset($group_name)) {
 
-  $delete_query = "${LDAP['group_attribute']}=" . ldap_escape($group_name, "", LDAP_ESCAPE_FILTER) . ",${LDAP['group_dn']}";
+  $delete_query = "{$LDAP['group_attribute']}=" . ldap_escape($group_name, "", LDAP_ESCAPE_FILTER) . ",{$LDAP['group_dn']}";
   $delete = @ ldap_delete($ldap_connection, $delete_query);
 
   if ($delete) {
@@ -714,8 +714,8 @@ function ldap_get_gid_of_group($ldap_connection,$group_name) {
 
  if (isset($group_name)) {
 
-  $ldap_search_query = "(${LDAP['group_attribute']}=" . ldap_escape($group_name, "", LDAP_ESCAPE_FILTER) . ")";
-  $ldap_search = @ ldap_search($ldap_connection, "${LDAP['group_dn']}", $ldap_search_query , array("gidNumber"));
+  $ldap_search_query = "({$LDAP['group_attribute']}=" . ldap_escape($group_name, "", LDAP_ESCAPE_FILTER) . ")";
+  $ldap_search = @ ldap_search($ldap_connection, "{$LDAP['group_dn']}", $ldap_search_query , array("gidNumber"));
   $result = @ ldap_get_entries($ldap_connection, $ldap_search);
 
   if (isset($result[0]['gidnumber'][0]) and is_numeric($result[0]['gidnumber'][0])) {
@@ -738,7 +738,7 @@ function ldap_get_group_name_from_gid($ldap_connection,$gid) {
  if (isset($gid)) {
 
   $ldap_search_query = "(gidnumber=" . ldap_escape($gid, "", LDAP_ESCAPE_FILTER) . ")";
-  $ldap_search = @ ldap_search($ldap_connection, "${LDAP['group_dn']}", $ldap_search_query , array("cn"));
+  $ldap_search = @ ldap_search($ldap_connection, "{$LDAP['group_dn']}", $ldap_search_query , array("cn"));
   $result = @ ldap_get_entries($ldap_connection, $ldap_search);
 
   if (isset($result[0]['cn'][0])) {
@@ -823,7 +823,7 @@ function ldap_new_account($ldap_connection,$account_r) {
 
    $account_identifier = $account_r[$LDAP['account_attribute']][0];
    $user_dn=$LDAP['user_dn'];
-   $ldap_search_query = "(${LDAP['account_attribute']}=" . ldap_escape($account_identifier, "", LDAP_ESCAPE_FILTER) . ",$user_dn)";
+   $ldap_search_query = "({$LDAP['account_attribute']}=" . ldap_escape($account_identifier, "", LDAP_ESCAPE_FILTER) . ",$user_dn)";
    $ldap_search = @ ldap_search($ldap_connection, $user_dn, $ldap_search_query);
    $result = @ ldap_get_entries($ldap_connection, $ldap_search);
 
@@ -865,7 +865,7 @@ function ldap_new_account($ldap_connection,$account_r) {
      if (empty($account_attributes['homedirectory'])) { $account_attributes['homedirectory'] = "/home/" . $account_r['uid'][0]; }
 
      $add_account = @ ldap_add($ldap_connection,
-                               "${LDAP['account_attribute']}=$account_identifier,${LDAP['user_dn']}",
+                               "{$LDAP['account_attribute']}=$account_identifier,{$LDAP['user_dn']}",
                                $account_attributes
                               );
 
@@ -877,7 +877,7 @@ function ldap_new_account($ldap_connection,$account_r) {
        $new_uid = $account_attributes['uidnumber'][0];
 
        if ($this_uid != FALSE) {
-         $update_uid = @ ldap_mod_replace($ldap_connection, "cn=lastUID,${LDAP['base_dn']}", array( 'serialNumber' => $new_uid ));
+         $update_uid = @ ldap_mod_replace($ldap_connection, "cn=lastUID,{$LDAP['base_dn']}", array( 'serialNumber' => $new_uid ));
          if ($update_uid) {
            error_log("$log_prefix Create account; Updated cn=lastUID with $new_uid",0);
          }
@@ -889,13 +889,13 @@ function ldap_new_account($ldap_connection,$account_r) {
      }
      else {
        ldap_get_option($ldap_connection, LDAP_OPT_DIAGNOSTIC_MESSAGE, $detailed_err);
-       error_log("$log_prefix Create account; couldn't create the account for ${account_identifier}: " . ldap_error($ldap_connection) . " -- " . $detailed_err,0);
+       error_log("$log_prefix Create account; couldn't create the account for {$account_identifier}: " . ldap_error($ldap_connection) . " -- " . $detailed_err,0);
      }
 
    }
 
    else {
-     error_log("$log_prefix Create account; Account for ${account_identifier} already exists",0);
+     error_log("$log_prefix Create account; Account for {$account_identifier} already exists",0);
    }
 
   }
@@ -916,7 +916,7 @@ function ldap_delete_account($ldap_connection,$username) {
 
  if (isset($username)) {
 
-  $delete_query = "${LDAP['account_attribute']}=" . ldap_escape($username, "", LDAP_ESCAPE_FILTER) . ",${LDAP['user_dn']}";
+  $delete_query = "{$LDAP['account_attribute']}=" . ldap_escape($username, "", LDAP_ESCAPE_FILTER) . ",{$LDAP['user_dn']}";
   $delete = @ ldap_delete($ldap_connection, $delete_query);
 
   if ($delete) {
@@ -924,7 +924,7 @@ function ldap_delete_account($ldap_connection,$username) {
    return TRUE;
   }
   else {
-   error_log("$log_prefix Couldn't delete account for ${username}: " . ldap_error($ldap_connection),0);
+   error_log("$log_prefix Couldn't delete account for {$username}: " . ldap_error($ldap_connection),0);
    return FALSE;
   }
 
@@ -941,10 +941,10 @@ function ldap_add_member_to_group($ldap_connection,$group_name,$username) {
 
   $rfc2307bis_available = ldap_detect_rfc2307bis($ldap_connection);
 
-  $group_dn = "${LDAP['group_attribute']}=" . ldap_escape($group_name, "", LDAP_ESCAPE_FILTER) . ",${LDAP['group_dn']}";
+  $group_dn = "{$LDAP['group_attribute']}=" . ldap_escape($group_name, "", LDAP_ESCAPE_FILTER) . ",{$LDAP['group_dn']}";
 
   if ($LDAP['group_membership_uses_uid'] == FALSE) {
-   $username = "${LDAP['account_attribute']}=$username,${LDAP['user_dn']}";
+   $username = "{$LDAP['account_attribute']}=$username,{$LDAP['user_dn']}";
   }
 
   $group_update = array($LDAP['group_membership_attribute'] => $username);
@@ -956,7 +956,7 @@ function ldap_add_member_to_group($ldap_connection,$group_name,$username) {
   }
   else {
    ldap_get_option($ldap_connection, LDAP_OPT_DIAGNOSTIC_MESSAGE, $detailed_err);
-   error_log("$log_prefix Couldn't add $username to group '${group_name}': " . ldap_error($ldap_connection) . " -- " . $detailed_err,0);
+   error_log("$log_prefix Couldn't add $username to group '{$group_name}': " . ldap_error($ldap_connection) . " -- " . $detailed_err,0);
    return FALSE;
   }
 
@@ -970,16 +970,16 @@ function ldap_delete_member_from_group($ldap_connection,$group_name,$username) {
   global $log_prefix, $LDAP, $LDAP_DEBUG, $USER_ID;
 
   if ($group_name == $LDAP['admins_group'] and $username == $USER_ID) {
-    error_log("$log_prefix Won't remove ${username} from ${group_name} because you're logged in as ${username} and ${group_name} is the admin group.",0);
+    error_log("$log_prefix Won't remove {$username} from {$group_name} because you're logged in as {$username} and {$group_name} is the admin group.",0);
     return FALSE;
   }
   else {
     $rfc2307bis_available = ldap_detect_rfc2307bis($ldap_connection);
 
-    $group_dn = "${LDAP['group_attribute']}=" . ldap_escape($group_name, "", LDAP_ESCAPE_FILTER) . ",${LDAP['group_dn']}";
+    $group_dn = "{$LDAP['group_attribute']}=" . ldap_escape($group_name, "", LDAP_ESCAPE_FILTER) . ",{$LDAP['group_dn']}";
 
     if ($LDAP['group_membership_uses_uid'] == FALSE and $username != "") {
-      $username = "${LDAP['account_attribute']}=$username,${LDAP['user_dn']}";
+      $username = "{$LDAP['account_attribute']}=$username,{$LDAP['user_dn']}";
     }
 
     $group_update = array($LDAP['group_membership_attribute'] => $username);
@@ -990,7 +990,7 @@ function ldap_delete_member_from_group($ldap_connection,$group_name,$username) {
      return TRUE;
     }
     else {
-     error_log("$log_prefix Couldn't remove '$username' from ${group_name}: " . ldap_error($ldap_connection),0);
+     error_log("$log_prefix Couldn't remove '$username' from {$group_name}: " . ldap_error($ldap_connection),0);
      return FALSE;
     }
   }
@@ -1005,7 +1005,7 @@ function ldap_change_password($ldap_connection,$username,$new_password) {
 
  #Find DN of user
 
- $ldap_search_query = "${LDAP['account_attribute']}=" . ldap_escape($username, "", LDAP_ESCAPE_FILTER);
+ $ldap_search_query = "{$LDAP['account_attribute']}=" . ldap_escape($username, "", LDAP_ESCAPE_FILTER);
  $ldap_search = @ ldap_search( $ldap_connection, $LDAP['user_dn'], $ldap_search_query);
  if ($ldap_search) {
   $result = @ ldap_get_entries($ldap_connection, $ldap_search);
@@ -1018,7 +1018,7 @@ function ldap_change_password($ldap_connection,$username,$new_password) {
   }
  }
  else {
-  error_log("$log_prefix Couldn't perform an LDAP search for ${LDAP['account_attribute']}=${username}: " . ldap_error($ldap_connection),0);
+  error_log("$log_prefix Couldn't perform an LDAP search for {$LDAP['account_attribute']}={$username}: " . ldap_error($ldap_connection),0);
   return FALSE;
  }
 
@@ -1030,7 +1030,7 @@ function ldap_change_password($ldap_connection,$username,$new_password) {
   return TRUE;
  }
  else {
-  error_log("$log_prefix Couldn't update the password for ${username}: " . ldap_error($ldap_connection),0);
+  error_log("$log_prefix Couldn't update the password for {$username}: " . ldap_error($ldap_connection),0);
   return TRUE;
  }
 
@@ -1059,7 +1059,7 @@ function ldap_detect_rfc2307bis($ldap_connection) {
       $schema_base_query = @ ldap_read($ldap_connection,"","subschemaSubentry=*",array('subschemaSubentry'));
 
       if (!$schema_base_query) {
-        error_log("$log_prefix LDAP RFC2307BIS detection - unable to query LDAP for objectClasses under ${schema_base_dn}:" . ldap_error($ldap_connection),0);
+        error_log("$log_prefix LDAP RFC2307BIS detection - unable to query LDAP for objectClasses under {$schema_base_dn}:" . ldap_error($ldap_connection),0);
         error_log("$log_prefix LDAP RFC2307BIS detection - we'll assume that the RFC2307BIS schema isn't available.  Set FORCE_RFC2307BIS to TRUE if you DO use RFC2307BIS.",0);
       }
       else {
@@ -1072,7 +1072,7 @@ function ldap_detect_rfc2307bis($ldap_connection) {
 
           $objclass_query = @ ldap_read($ldap_connection,$schema_base_dn,"(objectClasses=*)",array('objectClasses'));
           if (!$objclass_query) {
-            error_log("$log_prefix LDAP RFC2307BIS detection - unable to query LDAP for objectClasses under ${schema_base_dn}:" . ldap_error($ldap_connection),0);
+            error_log("$log_prefix LDAP RFC2307BIS detection - unable to query LDAP for objectClasses under {$schema_base_dn}:" . ldap_error($ldap_connection),0);
           }
           else {
             $objclass_results = @ ldap_get_entries($ldap_connection, $objclass_query);

--- a/www/includes/mail_functions.inc.php
+++ b/www/includes/mail_functions.inc.php
@@ -34,8 +34,8 @@ function parse_mail_text($template,$password,$login,$first_name,$last_name) {
   $template = str_replace("{last_name}", $last_name, $template);
 
   $template = str_replace("{organisation}", $ORGANISATION_NAME, $template);
-  $template = str_replace("{site_url}", "${SITE_PROTOCOL}${SERVER_HOSTNAME}${SERVER_PATH}", $template);
-  $template = str_replace("{change_password_url}", "${SITE_PROTOCOL}${SERVER_HOSTNAME}${SERVER_PATH}change_password", $template);
+  $template = str_replace("{site_url}", "{$SITE_PROTOCOL}{$SERVER_HOSTNAME}{$SERVER_PATH}", $template);
+  $template = str_replace("{change_password_url}", "{$SITE_PROTOCOL}{$SERVER_HOSTNAME}{$SERVER_PATH}change_password", $template);
 
   return $template;
 

--- a/www/includes/web_functions.inc.php
+++ b/www/includes/web_functions.inc.php
@@ -33,7 +33,7 @@ include ("config.inc.php");    # get local settings
 include ("modules.inc.php");   # module definitions
 
 if (substr($SERVER_PATH, -1) != "/") { $SERVER_PATH .= "/"; }
-$THIS_MODULE_PATH="${SERVER_PATH}${THIS_MODULE}";
+$THIS_MODULE_PATH="{$SERVER_PATH}{$THIS_MODULE}";
 
 $DEFAULT_COOKIE_OPTIONS = array( 'expires' => time()+(60 * $SESSION_TIMEOUT),
                                  'path' => $SERVER_PATH,
@@ -84,7 +84,7 @@ function set_passkey_cookie($user_id,$is_admin) {
  $sessto_cookie_opts = $DEFAULT_COOKIE_OPTIONS;
  $sessto_cookie_opts['expires'] = $this_time+7200;
  setcookie('sessto_cookie', $this_time+(60 * $SESSION_TIMEOUT), $sessto_cookie_opts);
- if ( $SESSION_DEBUG == TRUE) {  error_log("$log_prefix Session: user $user_id validated (IS_ADMIN=${IS_ADMIN}), sent orf_cookie to the browser.",0); }
+ if ( $SESSION_DEBUG == TRUE) {  error_log("$log_prefix Session: user $user_id validated (IS_ADMIN={$IS_ADMIN}), sent orf_cookie to the browser.",0); }
  $VALIDATED = TRUE;
 
 }
@@ -129,7 +129,7 @@ function validate_passkey_cookie() {
         if ($f_is_admin == 1) { $IS_ADMIN = TRUE; }
         $VALIDATED = TRUE;
         $USER_ID=$user_id;
-        if ($SESSION_DEBUG == TRUE) {  error_log("$log_prefix Setup session: Cookie and session file values match for user ${user_id} - VALIDATED (ADMIN = ${IS_ADMIN})",0); }
+        if ($SESSION_DEBUG == TRUE) {  error_log("$log_prefix Setup session: Cookie and session file values match for user {$user_id} - VALIDATED (ADMIN = {$IS_ADMIN})",0); }
         set_passkey_cookie($USER_ID,$IS_ADMIN);
       }
       else {
@@ -137,7 +137,7 @@ function validate_passkey_cookie() {
           $this_error="$log_prefix Session: orf_cookie was sent by the client and the session file was found at /tmp/$filename, but";
           if (empty($c_passkey)) { $this_error .= " the cookie passkey wasn't set;"; }
           if ($c_passkey != $f_passkey) { $this_error .= " the session file passkey didn't match the cookie passkey;"; }
-          $this_error.=" Cookie: ${_COOKIE['orf_cookie']} - Session file contents: $session_file";
+          $this_error.=" Cookie: {$_COOKIE['orf_cookie']} - Session file contents: $session_file";
           error_log($this_error,0);
         }
       }
@@ -205,7 +205,7 @@ function validate_setup_cookie() {
    $this_error="$log_prefix Setup session: setup_cookie was sent by the client and the session file was found at /tmp/ldap_setup, but";
    if (empty($c_passkey)) { $this_error .= " the cookie passkey wasn't set;"; }
    if ($c_passkey != $f_passkey) { $this_error .= " the session file passkey didn't match the cookie passkey;"; }
-   $this_error += " Cookie: ${_COOKIE['setup_cookie']} - Session file contents: $session_file";
+   $this_error += " Cookie: {$_COOKIE['setup_cookie']} - Session file contents: $session_file";
    error_log($this_error,0);
   }
  }
@@ -238,7 +238,7 @@ function log_out($method='normal') {
  @ unlink("/tmp/$filename");
 
  if ($method == 'auto') { $options = "?logged_out"; } else { $options = ""; }
- header("Location:  //${_SERVER["HTTP_HOST"]}${SERVER_PATH}index.php$options\n\n");
+ header("Location:  //{$_SERVER["HTTP_HOST"]}{$SERVER_PATH}index.php$options\n\n");
 
 }
 
@@ -325,7 +325,7 @@ function render_menu() {
        else {
         print '<li>';
        }
-       print "<a href='${SERVER_PATH}{$module}/'>$this_module_name</a></li>\n";
+       print "<a href='{$SERVER_PATH}{$module}/'>$this_module_name</a></li>\n";
       }
      }
      ?>
@@ -369,7 +369,7 @@ function set_page_access($level) {
    return;
   }
   else {
-   header("Location: //" . $_SERVER["HTTP_HOST"] . "${SERVER_PATH}setup/index.php?unauthorised\n\n");
+   header("Location: //" . $_SERVER["HTTP_HOST"] . "{$SERVER_PATH}setup/index.php?unauthorised\n\n");
    if ( $SESSION_DEBUG == TRUE) {  error_log("$log_prefix Session: UNAUTHORISED: page security level is 'setup' but IS_SETUP_ADMIN isn't TRUE",0); }
    exit(0);
   }
@@ -382,8 +382,8 @@ function set_page_access($level) {
    return;
   }
   else {
-   header("Location: //" . $_SERVER["HTTP_HOST"] . "${SERVER_PATH}log_in/index.php?$reason&redirect_to=" . base64_encode($_SERVER['REQUEST_URI']) . "\n\n");
-   if ( $SESSION_DEBUG == TRUE) {  error_log("$log_prefix Session: no access to page ($reason): page security level is 'admin' but IS_ADMIN = '${IS_ADMIN}' and VALIDATED = '${VALIDATED}' (user) ",0); }
+   header("Location: //" . $_SERVER["HTTP_HOST"] . "{$SERVER_PATH}log_in/index.php?$reason&redirect_to=" . base64_encode($_SERVER['REQUEST_URI']) . "\n\n");
+   if ( $SESSION_DEBUG == TRUE) {  error_log("$log_prefix Session: no access to page ($reason): page security level is 'admin' but IS_ADMIN = '{$IS_ADMIN}' and VALIDATED = '{$VALIDATED}' (user) ",0); }
    exit(0);
   }
  }
@@ -393,8 +393,8 @@ function set_page_access($level) {
    return;
   }
   else {
-   header("Location: //" . $_SERVER["HTTP_HOST"] . "${SERVER_PATH}log_in/index.php?$reason&redirect_to=" . base64_encode($_SERVER['REQUEST_URI']) . "\n\n");
-   if ( $SESSION_DEBUG == TRUE) {  error_log("$log_prefix Session: no access to page ($reason): page security level is 'user' but VALIDATED = '${VALIDATED}'",0); }
+   header("Location: //" . $_SERVER["HTTP_HOST"] . "{$SERVER_PATH}log_in/index.php?$reason&redirect_to=" . base64_encode($_SERVER['REQUEST_URI']) . "\n\n");
+   if ( $SESSION_DEBUG == TRUE) {  error_log("$log_prefix Session: no access to page ($reason): page security level is 'user' but VALIDATED = '{$VALIDATED}'",0); }
    exit(0);
   }
  }
@@ -679,7 +679,7 @@ function render_attribute_fields($attribute,$label,$values_r,$resource_identifie
                  $description="Download $mimetype file (" . human_readable_filesize(strlen($values_r[0])) . ")";
                  $button_text="Replace file";
                  if ($resource_identifier != "") {
-                   $this_url="//${_SERVER['HTTP_HOST']}${THIS_MODULE_PATH}/download.php?resource_identifier=${resource_identifier}&attribute=${attribute}";
+                   $this_url="//{$_SERVER['HTTP_HOST']}{$THIS_MODULE_PATH}/download.php?resource_identifier={$resource_identifier}&attribute={$attribute}";
                    $file_button_action="onclick=\"window.open('$this_url','_blank');\"";
                  }
                }

--- a/www/log_in/index.php
+++ b/www/log_in/index.php
@@ -31,16 +31,16 @@ if (isset($_POST["user_id"]) and isset($_POST["password"])) {
 
   set_passkey_cookie($user_auth,$is_admin);
   if (isset($_POST["redirect_to"])) {
-   header("Location: //${_SERVER['HTTP_HOST']}" . base64_decode($_POST['redirect_to']) . "\n\n");
+   header("Location: //{$_SERVER['HTTP_HOST']}" . base64_decode($_POST['redirect_to']) . "\n\n");
   }
   else {
 
    if ($IS_ADMIN) { $default_module = "account_manager"; } else { $default_module = "change_password"; }
-   header("Location: //${_SERVER['HTTP_HOST']}${SERVER_PATH}$default_module?logged_in\n\n");
+   header("Location: //{$_SERVER['HTTP_HOST']}{$SERVER_PATH}$default_module?logged_in\n\n");
   }
  }
  else {
-  header("Location: //${_SERVER['HTTP_HOST']}${THIS_MODULE_PATH}/index.php?invalid\n\n");
+  header("Location: //{$_SERVER['HTTP_HOST']}{$THIS_MODULE_PATH}/index.php?invalid\n\n");
  }
 
 }

--- a/www/setup/index.php
+++ b/www/setup/index.php
@@ -13,10 +13,10 @@ if (isset($_POST["admin_password"])) {
 
  if ($user_auth != FALSE) {
   set_setup_cookie($user_auth);
-  header("Location: //${_SERVER["HTTP_HOST"]}${THIS_MODULE_PATH}/run_checks.php\n\n");
+  header("Location: //{$_SERVER["HTTP_HOST"]}{$THIS_MODULE_PATH}/run_checks.php\n\n");
  }
  else {
-  header("Location: //${_SERVER["HTTP_HOST"]}${THIS_MODULE_PATH}/index.php?invalid\n\n");
+  header("Location: //{$_SERVER["HTTP_HOST"]}{$THIS_MODULE_PATH}/index.php?invalid\n\n");
  }
 
 }


### PR DESCRIPTION
This is a quite simple fix for the deprecation of the old string formatting in php 8.2. I noticed to problem when I build the docker image myself.
See: https://wiki.php.net/rfc/deprecate_dollar_brace_string_interpolation