### PR TITLE
add smtp helo host

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,8 @@ To send emails you'll need to use an existing SMTP server.  Email sending will b
    
 * `SMTP_HOST_PORT` (default: *25*): The SMTP port on the SMTP server.
    
+* `SMTP_HELO_HOST` (no default): The hostname to send with the HELO/EHLO command.
+
 * `SMTP_USERNAME` (no default): The username to use when the SMTP server requires authentication.
    
 * `SMTP_PASSWORD` (no default): The password to use when the SMTP server requires authentication.

--- a/www/includes/config.inc.php
+++ b/www/includes/config.inc.php
@@ -134,6 +134,7 @@
  $SMTP['user'] = (getenv('SMTP_USERNAME') ? getenv('SMTP_USERNAME') : NULL);
  $SMTP['pass'] = (getenv('SMTP_PASSWORD') ? getenv('SMTP_PASSWORD') : NULL);
  $SMTP['port'] = (getenv('SMTP_HOST_PORT') ? getenv('SMTP_HOST_PORT') : 25);
+ $SMTP['helo'] = (getenv('SMTP_HELO_HOST') ? getenv('SMTP_HELO_HOST') : NULL);
  $SMTP['ssl']  = ((strcasecmp(getenv('SMTP_USE_SSL'),'TRUE') == 0) ? TRUE : FALSE);
  $SMTP['tls']  = ((strcasecmp(getenv('SMTP_USE_TLS'),'TRUE') == 0) ? TRUE : FALSE);
  if ($SMTP['tls'] == TRUE) { $SMTP['ssl'] = FALSE; }

--- a/www/includes/mail_functions.inc.php
+++ b/www/includes/mail_functions.inc.php
@@ -55,6 +55,10 @@ function send_email($recipient_email,$recipient_name,$subject,$body) {
   $mail->Host = $SMTP['host'];
   $mail->Port = $SMTP['port'];
 
+  if (isset($SMTP['helo'])) {
+    $mail->Helo = $SMTP['helo'];
+  }
+
   if (isset($SMTP['user'])) {
     $mail->SMTPAuth = true;
     $mail->Username = $SMTP['user'];


### PR DESCRIPTION
added a hostname parameter for HELO/EHLO command.
It is useful to send an email via google workspace without authentication.
https://support.google.com/a/answer/2956491
