### PR TITLE
Fix LDAP TLS CA certificate file ignored

### DIFF
--- a/entrypoint
+++ b/entrypoint
@@ -4,16 +4,15 @@ set -e
 ssl_dir="/opt/ssl"
 php_dir="/opt/ldap_user_manager"
 
-env_file_replace() {
-  for env_file in $(env|grep _FILE=); do
-    read -a env <<< "$(echo "$env_file" | sed 's/\(.*\)_FILE=\(.*\)/\1 \2/')"
-    if [ -s "${env[1]}" ]; then
-      echo Setting "${env[0]}" from "${env[1]}"
-      export "${env[0]}"="$(cat "${env[1]}")"
-      else echo "${env[1]} does not exist or is empty. Leaving ${env[0]} unset"
-    fi
-  done
-}
+#If <env_var>_FILE is set, read and export env_var from the referenced file's contents
+for env_file in $(env|grep _FILE=); do
+  read -a env <<< "$(echo "$env_file" | sed 's/\(.*\)_FILE=\(.*\)/\1 \2/')"
+  if [ -s "${env[1]}" ]; then
+    echo Setting "${env[0]}" from "${env[1]}"
+    export "${env[0]}"="$(cat "${env[1]}")"
+    else echo "${env[1]} does not exist or is empty. Leaving ${env[0]} unset"
+  fi
+done
 
 if [ ! "$SERVER_HOSTNAME" ]; then export SERVER_HOSTNAME="ldapusermanager.org"; fi
 if [ ! "$SERVER_PATH" ]; then
@@ -171,10 +170,6 @@ EoHTTPrd
 EoHTTPSC
 
 fi
-
-########################
-#If <env_var>_FILE is set, read and export env_var from the referenced file's contents
-env_file_replace
 
 ########################
 #Run Apache


### PR DESCRIPTION
`_FILE` env vars should be replaced asap in the [`entrypoint`](https://github.com/wheelybird/ldap-user-manager/blob/master/entrypoint), otherwise they won't be available for [most of the script](https://github.com/wheelybird/ldap-user-manager/blob/master/entrypoint#L18-L167) and result in undesired behavior, such as the `LDAP_TLS_CACERT_FILE` var having no effect.