### PR TITLE
Configure GD extension with JPEG support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update && \
         cron && \
     rm -rf /var/lib/apt/lists/*
 
-RUN docker-php-ext-configure gd --with-freetype && \
+RUN docker-php-ext-configure gd --with-freetype --with-jpeg && \
     docker-php-ext-install -j$(nproc) gd && \
     libdir=$(find /usr -name "libldap.so*" -type f | head -1 | xargs dirname | sed 's|/usr/||') && \
     docker-php-ext-configure ldap --with-libdir=$libdir && \


### PR DESCRIPTION
you need GD jpeg support for profile pictures, else when you select pictures that are not jpeg then the php function you have written wil fail and the site ends up with an error.

I have a nasty workaround in kubernetes for this, but changing the docker images is cleaner :)

snippet for anyone that finds this.
```
spec:
  replicas: 1
  selector:
    matchLabels:
      app: luminary
  template:
    metadata:
      labels:
        app: luminary
    spec:
      containers:
      - name: luminary
        image: wheelybird/luminary:latest
        ports:
        - containerPort: 80
        lifecycle:
          postStart:
            exec:
              command: 
                - /bin/bash
                - -c
                - |
                  apt-get update && \
                  apt-get install -y libpng-dev libjpeg-dev libfreetype6-dev && \
                  docker-php-ext-configure gd --with-freetype --with-jpeg && \
                  docker-php-ext-install gd && \
                  apache2ctl graceful
        env:
        ###############################################################
        #            Mandatory LDAP Settings         #
        ###############################################################
        - name: LDAP_URI
```