### PR TITLE
automatically load configuration from file

### DIFF
--- a/www/includes/config_registry.inc.php
+++ b/www/includes/config_registry.inc.php
@@ -19,6 +19,16 @@
  * - display_code: Whether to display in <code> tags
  */
 
+// Load configuration from file if CONFIG_FILE is set
+$config_file = getenv('CONFIG_FILE');
+if ($config_file && file_exists($config_file)) {
+    $config = parse_ini_file($config_file);
+    foreach ($config as $key => $value) {
+        putenv("$key=$value");
+        $_ENV[$key] = $value;
+    }
+}
+
 # Category definitions - groups related configurations together
 $CONFIG_CATEGORIES = array(
   'ldap' => array(


### PR DESCRIPTION
According to the document, we have to add those lines if we’re not using the Docker version of the app. But we can add those lines in the main code. That way, if the env var is set, it will use the config file, otherwise, nothing changes.