### PR TITLE
Fix fatal error from duplicate ldap_functions.inc.php includes in MFA…

### DIFF
--- a/www/log_in/account_expired.php
+++ b/www/log_in/account_expired.php
@@ -3,7 +3,7 @@
 set_include_path( ".:" . __DIR__ . "/../includes/");
 
 include "web_functions.inc.php";
-include "ldap_functions.inc.php";
+include_once "ldap_functions.inc.php";
 include "account_lifecycle_functions.inc.php";
 
 // Must be logged in to see this page


### PR DESCRIPTION
…/account-expiry pages

Problem
log_in/account_expired.php and log_in/verify_totp.php use include instead of include_once for ldap_functions.inc.php. When either page is reached after ldap_functions.inc.php has already been loaded earlier in the same request — which happens on the MFA-required and account-expired login redirect paths in log_in/index.php — this throws: PHP Fatal error: Cannot redeclare function open_ldap_connection() Every other file in the codebase already uses include_once/require_once for this file; these two were the only exceptions. Fix
Changed include → include_once in both files, matching the convention used everywhere else. Files changed

www/log_in/account_expired.php
www/log_in/verify_totp.php

Testing
Reproduced on a live deployment with MFA_FEATURE_ENABLED=TRUE and account lifecycle enabled — confirmed the fatal error occurs on the affected redirect paths before the fix, and is resolved after. Note
Built and tested against the version currently deployed in our environment — if master has since changed in this area, happy to adjust the diff.